### PR TITLE
adding pre-commit and markdownlint configs

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "default": true,
+  "line-length": false,
+  "no-inline-html": {
+    "allowed_elements": ["details", "img"]
+  },
+  "ol-prefix": false,
+  "list-indent": false,
+  "ul-indent": false,
+  "no-multiple-blanks": false,
+  "ul-style": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: check-yaml
+    exclude: '\.*conda/.*'
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+    exclude: '\.txt$|\.tsv$'
+  - id: check-case-conflict
+  - id: check-merge-conflict
+  - id: detect-private-key
+  - id: debug-statements
+  - id: check-added-large-files
+
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.26.0
+  hooks:
+  - id: markdownlint
+    args: ['--config', '.markdownlint.json']
+
+- repo: https://github.com/ambv/black
+  rev: 20.8b1
+  hooks:
+  - id: black
+
+- repo: https://gitlab.com/pycqa/flake8
+  rev: '3.8.4'
+  hooks:
+  - id: flake8
+    additional_dependencies: [flake8-bugbear, flake8-quotes]
+
+# Using system installation of pylint to support checking python module imports
+- repo: local
+  hooks:
+  - id: pylint
+    name: pylint
+    entry: pylint
+    language: system
+    types: [python]


### PR DESCRIPTION
Adding [pre-commit](https://pre-commit.com/) config mainly for Markdown and Python files.