### PR TITLE
ExpansionHunter for STRs

### DIFF
--- a/gatk-sv/.gitignore
+++ b/gatk-sv/.gitignore
@@ -1,1 +1,1 @@
-./gatk-sv-git/
+gatk-sv-github/

--- a/str/ExpansionHunter.wdl
+++ b/str/ExpansionHunter.wdl
@@ -84,7 +84,7 @@ task RunExpansionHunter {
 
     RuntimeAttr runtime_attr_str_profile_default = object {
         cpu_cores: 1,
-        mem_gb: 4,
+        mem_gb: 16,
         boot_disk_gb: 10,
         preemptible_tries: 3,
         max_retries: 1,

--- a/str/ExpansionHunter.wdl
+++ b/str/ExpansionHunter.wdl
@@ -1,0 +1,110 @@
+##  This WDL implements workflow for ExpansionHunter.
+
+version 1.0
+
+import "https://raw.githubusercontent.com/populationgenomics/gatk-sv/v0.17.1-beta/wdl/Structs.wdl"
+
+struct FilenamePostfixes {
+    String locus
+    String motif
+    String profile
+    String merged_profile
+    Int profile_len
+}
+
+workflow ExpansionHunter {
+
+    input {
+        File bam_or_cram
+        File? bam_or_cram_index
+        File reference_fasta
+        File? reference_fasta_index
+        File variant_catalog
+        String docker_file
+        RuntimeAttr? runtime_attr
+    }
+
+    Boolean is_bam = basename(bam_or_cram, ".bam") + ".bam" == basename(bam_or_cram)
+    File bam_or_cram_index_ =
+        if defined(bam_or_cram_index) then
+            select_first([bam_or_cram_index])
+        else
+            bam_or_cram + if is_bam then ".bai" else ".crai"
+
+    File reference_fasta_index_ = select_first([
+        reference_fasta_index,
+        reference_fasta + ".fai"])
+
+    call RunExpansionHunter {
+        input:
+            bam_or_cram = bam_or_cram,
+            bam_or_cram_index = bam_or_cram_index_,
+            reference_fasta = reference_fasta,
+            reference_fasta_index = reference_fasta_index_,
+            variant_catalog = variant_catalog,
+            docker_file = docker_file,
+            runtime_attr_override = runtime_attr,
+    }
+
+    output {
+        File json = RunExpansionHunter.json
+        File vcf = RunExpansionHunter.vcf
+        File overlapping_reads = RunExpansionHunter.overlapping_reads
+    }
+}
+
+task RunExpansionHunter {
+    input {
+        File bam_or_cram
+        File bam_or_cram_index
+        File reference_fasta
+        File reference_fasta_index
+        File variant_catalog
+        String docker_file
+        RuntimeAttr? runtime_attr_override
+    }
+
+    String output_prefix = "output"
+
+    output {
+        File json = "${output_prefix}.json"
+        File vcf = "${output_prefix}.vcf"
+        File overlapping_reads = "${output_prefix}_realigned.bam"
+    }
+
+    command <<<
+        set -euxo pipefail
+
+        ExpansionHunter \
+            --reads ~{bam_or_cram} \
+            --reference ~{reference_fasta} \
+            --variant-catalog ~{variant_catalog} \
+            --output-prefix ~{output_prefix}
+    >>>
+
+    RuntimeAttr runtime_attr_str_profile_default = object {
+        cpu_cores: 1,
+        mem_gb: 4,
+        boot_disk_gb: 10,
+        preemptible_tries: 3,
+        max_retries: 1,
+        disk_gb: 10 + ceil(size([
+            bam_or_cram,
+            bam_or_cram_index,
+            reference_fasta,
+            reference_fasta_index], "GiB"))
+    }
+    RuntimeAttr runtime_attr = select_first([
+        runtime_attr_override,
+        runtime_attr_str_profile_default])
+
+    runtime {
+        docker: docker_file
+        cpu: runtime_attr.cpu_cores
+        memory: runtime_attr.mem_gb + " GiB"
+        disks: "local-disk " + runtime_attr.disk_gb + " HDD"
+        bootDiskSizeGb: runtime_attr.boot_disk_gb
+        preemptible: runtime_attr.preemptible_tries
+        maxRetries: runtime_attr.max_retries
+    }
+}

--- a/str/inputs/general.json
+++ b/str/inputs/general.json
@@ -1,0 +1,6 @@
+{
+  "ExpansionHunter.docker_file": "quay.io/biocontainers/expansionhunter:4.0.2--he785bd8_0",
+  "ExpansionHunter.reference_fasta": "gs://cpg-reference/hg38/v0/Homo_sapiens_assembly38.fasta",
+  "ExpansionHunter.variant_catalog": "gs://cpg-reference/hg38/v0/str/expansionhunter/variant_catalog_hg38_2021-08-18.json"
+}
+


### PR DESCRIPTION
Running ExpansionHunter (for Short Tandem Repeat genotyping) based on GATK-SV WDL (still unmerged PR). Tested on NA12878, HGDP01357 and TOB1520.

Closes #22.

Interestingly, runtime for NA12878 _BAM_ (using 4G) was ~1hr. Using same mem for HGDP + TOB _CRAMs_ errored out, so I bumped it to 16G and both completed within 20min.

Further improvements would be to copy the quay docker image to our own AR.
I'm also leaning more towards using https imports in WDL files - I feel it's more convenient than using submodules. I can change to commit hash instead of tag if required.