### PR TITLE
add gcloud auth for docker

### DIFF
--- a/gatk-sv/scripts/docker_sync.sh
+++ b/gatk-sv/scripts/docker_sync.sh
@@ -4,4 +4,5 @@ set -ex
 
 micromamba install -y --prefix $MAMBA_ROOT_PREFIX -y -c conda-forge skopeo
 
+gcloud auth configure-docker australia-southeast1-docker.pkg.dev
 skopeo copy docker://australia-southeast1-docker.pkg.dev/peter-dev-302805/test/melt:2.2.2 docker://australia-southeast1-docker.pkg.dev/cpg-common/images/sv/melt:2.2.2


### PR DESCRIPTION
Think this is why it's not working. Otherwise getting this with the analysis-runner:

```
skopeo copy docker://australia-southeast1-docker.pkg.dev/peter-dev-302805/test/melt:2.2.2 docker://australia-southeast1-docker.pkg.dev/cpg-common/images/sv/melt:2.2.2
time="2021-09-09T02:41:09Z" level=fatal msg="Error initializing source docker://australia-southeast1-docker.pkg.dev/peter-dev-302805/test/melt:2.2.2: Requesting bear token: invalid status code from registry 403 (Forbidden)"
```