### PR TITLE
TrainGCNV test

### DIFF
--- a/gatk-sv/test/TrainGCNV.wdl
+++ b/gatk-sv/test/TrainGCNV.wdl
@@ -1,0 +1,205 @@
+version 1.0
+
+import "gatk-sv-git/wdl/Structs.wdl"
+import "gatk-sv-git/wdl/CollectCoverage.wdl" as cov
+import "gatk-sv-git/wdl/CramToBam.wdl" as ctb
+import "gatk-sv-git/wdl/GermlineCNVCohort.wdl" as gcnv_cohort
+import "gatk-sv-git/wdl/Utils.wdl" as util
+
+# Trains gCNV model on a cohort with counts already collected
+workflow TrainGCNV {
+  input {
+    Array[String] samples
+    Array[File] count_files
+
+    # Common parameters
+    String cohort
+    File reference_fasta
+    File reference_index    # Index (.fai), must be in same dir as fasta
+    File reference_dict     # Dictionary (.dict), must be in same dir as fasta
+
+    Int? n_samples_subsample # Number of samples to subsample from provided sample list for trainGCNV (rec: ~100)
+    Int subsample_seed = 42
+
+    # Condense read counts
+    Int? condense_num_bins
+    Int? condense_bin_size
+
+    # gCNV common inputs
+    Int ref_copy_number_autosomal_contigs
+    Array[String]? allosomal_contigs
+
+    # Interval filtering inputs
+    File? exclude_intervals_for_filter_intervals_ploidy
+    File? exclude_intervals_for_filter_intervals_cnv
+
+    # gCNV cohort mode inputs
+    Boolean? filter_intervals
+    File contig_ploidy_priors
+    Int num_intervals_per_scatter
+    Boolean? do_explicit_gc_correction
+    Boolean? gcnv_enable_bias_factors
+
+    # gCNV additional arguments
+    Float? gcnv_learning_rate
+    Int? gcnv_num_thermal_advi_iters
+    Int? gcnv_max_advi_iter_first_epoch
+    Int? gcnv_max_advi_iter_subsequent_epochs
+    Int? gcnv_max_training_epochs
+    Int? gcnv_min_training_epochs
+    Int? gcnv_convergence_snr_averaging_window
+    Int? gcnv_convergence_snr_countdown_window
+    Int? gcnv_cnv_coherence_length
+    String? gcnv_copy_number_posterior_expectation_mode
+    Int? gcnv_log_emission_sampling_rounds
+    Float? gcnv_p_alt
+    Float? gcnv_sample_psi_scale
+    Float? ploidy_sample_psi_scale
+
+    Float? gcnv_caller_update_convergence_threshold
+    Float? gcnv_class_coherence_length
+    Float? gcnv_convergence_snr_trigger_threshold
+    Float? gcnv_interval_psi_scale
+    Float? gcnv_log_emission_sampling_median_rel_error
+    Float? gcnv_log_mean_bias_standard_deviation
+    Int? gcnv_max_bias_factors
+    Int? gcnv_max_calling_iters
+    Float? ploidy_global_psi_scale
+    Float? ploidy_mean_bias_standard_deviation
+    Float? gcnv_depth_correction_tau
+
+    # gCNV model building arguments
+    Float? gcnv_model_learning_rate
+    Int? gcnv_model_num_thermal_advi_iters
+    Int? gcnv_model_max_advi_iter_first_epoch
+    Int? gcnv_model_max_advi_iter_subsequent_epochs
+    Int? gcnv_model_max_training_epochs
+    Int? gcnv_model_min_training_epochs
+    Int? gcnv_model_convergence_snr_averaging_window
+    Int? gcnv_model_convergence_snr_countdown_window
+    Int? gcnv_model_cnv_coherence_length
+    Int? gcnv_model_log_emission_sampling_rounds
+
+    # Docker
+    String sv_base_mini_docker
+    String linux_docker
+    String gatk_docker
+    String condense_counts_docker
+    String? sv_pipeline_base_docker # required if using n_samples_subsample to select samples
+
+    # Runtime configuration overrides
+    RuntimeAttr? condense_counts_runtime_attr
+    RuntimeAttr? counts_to_intervals_runtime_attr
+    RuntimeAttr? runtime_attr_annotate
+    RuntimeAttr? runtime_attr_filter
+    RuntimeAttr? runtime_attr_scatter
+    RuntimeAttr? runtime_attr_ploidy
+    RuntimeAttr? runtime_attr_cohort
+    RuntimeAttr? runtime_attr_bundle
+    RuntimeAttr? runtime_attr_postprocess
+    RuntimeAttr? runtime_attr_explode
+  }
+
+  if (defined(n_samples_subsample)) {
+    call util.RandomSubsampleStringArray {
+      input:
+        strings = samples,
+        seed = subsample_seed,
+        subset_size = select_first([n_samples_subsample]),
+        prefix = cohort,
+        sv_pipeline_base_docker = select_first([sv_pipeline_base_docker])
+    }
+  }
+
+  Array[Int] sample_indices = select_first([RandomSubsampleStringArray.subsample_indices_array, range(length(samples))])
+
+  scatter (i in sample_indices) {
+    call cov.CondenseReadCounts as CondenseReadCounts {
+      input:
+        counts = count_files[i],
+        sample = samples[i],
+        num_bins = condense_num_bins,
+        expected_bin_size = condense_bin_size,
+        condense_counts_docker = condense_counts_docker,
+        runtime_attr_override=condense_counts_runtime_attr
+    }
+  }
+
+  call cov.CountsToIntervals {
+    input:
+      counts = CondenseReadCounts.out[0],
+      output_name = "condensed_intervals",
+      linux_docker = linux_docker,
+      runtime_attr_override = counts_to_intervals_runtime_attr
+  }
+
+  call gcnv_cohort.CNVGermlineCohortWorkflow {
+    input:
+      preprocessed_intervals = CountsToIntervals.out,
+      filter_intervals = filter_intervals,
+      counts = CondenseReadCounts.out,
+      count_entity_ids = select_first([RandomSubsampleStringArray.subsampled_strings_array, samples]),
+      cohort_entity_id = cohort,
+      contig_ploidy_priors = contig_ploidy_priors,
+      num_intervals_per_scatter = num_intervals_per_scatter,
+      ref_fasta_dict = reference_dict,
+      ref_fasta_fai = reference_index,
+      ref_fasta = reference_fasta,
+      exclude_intervals_for_filter_intervals_ploidy=exclude_intervals_for_filter_intervals_ploidy,
+      exclude_intervals_for_filter_intervals_cnv=exclude_intervals_for_filter_intervals_cnv,
+      do_explicit_gc_correction = do_explicit_gc_correction,
+      gcnv_enable_bias_factors = gcnv_enable_bias_factors,
+      ref_copy_number_autosomal_contigs = ref_copy_number_autosomal_contigs,
+      allosomal_contigs = allosomal_contigs,
+      gatk_docker = gatk_docker,
+      linux_docker = linux_docker,
+      sv_base_mini_docker = sv_base_mini_docker,
+      gcnv_learning_rate = gcnv_learning_rate,
+      gcnv_max_advi_iter_first_epoch = gcnv_max_advi_iter_first_epoch,
+      gcnv_num_thermal_advi_iters = gcnv_model_num_thermal_advi_iters,
+      gcnv_max_advi_iter_subsequent_epochs = gcnv_model_max_advi_iter_subsequent_epochs,
+      gcnv_max_training_epochs = gcnv_model_max_training_epochs,
+      gcnv_min_training_epochs = gcnv_model_min_training_epochs,
+      gcnv_convergence_snr_averaging_window = gcnv_model_convergence_snr_averaging_window,
+      gcnv_convergence_snr_countdown_window = gcnv_model_convergence_snr_countdown_window,
+      gcnv_cnv_coherence_length = gcnv_model_cnv_coherence_length,
+      gcnv_class_coherence_length = gcnv_class_coherence_length,
+      gcnv_copy_number_posterior_expectation_mode = gcnv_copy_number_posterior_expectation_mode,
+      gcnv_log_emission_sampling_rounds = gcnv_model_log_emission_sampling_rounds,
+      gcnv_p_alt = gcnv_p_alt,
+      gcnv_sample_psi_scale = gcnv_sample_psi_scale,
+      ploidy_sample_psi_scale = ploidy_sample_psi_scale,
+      gcnv_caller_update_convergence_threshold = gcnv_caller_update_convergence_threshold,
+      gcnv_convergence_snr_trigger_threshold = gcnv_convergence_snr_trigger_threshold,
+      gcnv_interval_psi_scale = gcnv_interval_psi_scale,
+      gcnv_log_emission_sampling_median_rel_error = gcnv_log_emission_sampling_median_rel_error,
+      gcnv_log_mean_bias_standard_deviation = gcnv_log_mean_bias_standard_deviation,
+      gcnv_max_bias_factors = gcnv_max_bias_factors,
+      gcnv_max_calling_iters = gcnv_max_calling_iters,
+      ploidy_global_psi_scale = ploidy_global_psi_scale,
+      ploidy_mean_bias_standard_deviation = ploidy_mean_bias_standard_deviation,
+      gcnv_depth_correction_tau = gcnv_depth_correction_tau,
+      runtime_attr_annotate = runtime_attr_annotate,
+      runtime_attr_filter = runtime_attr_filter,
+      runtime_attr_scatter = runtime_attr_scatter,
+      runtime_attr_ploidy = runtime_attr_ploidy,
+      runtime_attr_cohort = runtime_attr_cohort,
+      runtime_attr_bundle = runtime_attr_bundle,
+      runtime_attr_postprocess = runtime_attr_postprocess,
+      runtime_attr_explode = runtime_attr_explode
+  }
+
+  output {
+    File? annotated_intervals = CNVGermlineCohortWorkflow.annotated_intervals
+    File? filtered_intervals_cnv = CNVGermlineCohortWorkflow.filtered_intervals_cnv
+    File? filtered_intervals_ploidy = CNVGermlineCohortWorkflow.filtered_intervals_ploidy
+    File? cohort_contig_ploidy_model_tar = CNVGermlineCohortWorkflow.contig_ploidy_model_tar
+    File? cohort_contig_ploidy_calls_tar = CNVGermlineCohortWorkflow.contig_ploidy_calls_tar
+    Array[File]? cohort_gcnv_model_tars = CNVGermlineCohortWorkflow.gcnv_model_tars
+    Array[Array[File]]? cohort_gcnv_calls_tars = CNVGermlineCohortWorkflow.gcnv_calls_tars
+    Array[File]? cohort_gcnv_tracking_tars = CNVGermlineCohortWorkflow.gcnv_tracking_tars
+    Array[File]? cohort_genotyped_intervals_vcfs = CNVGermlineCohortWorkflow.genotyped_intervals_vcfs
+    Array[File]? cohort_genotyped_segments_vcfs = CNVGermlineCohortWorkflow.genotyped_segments_vcfs
+    Array[File]? cohort_denoised_copy_ratios = CNVGermlineCohortWorkflow.denoised_copy_ratios
+  }
+}

--- a/gatk-sv/test/TrainGCNV_inputs.json
+++ b/gatk-sv/test/TrainGCNV_inputs.json
@@ -1,0 +1,56 @@
+{
+  "TrainGCNV.sv_pipeline_base_docker": "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline-base:lint-24b9cda",
+  "TrainGCNV.sv_base_mini_docker": "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-base-mini:lint-24b9cda",
+  "TrainGCNV.condense_counts_docker": "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:condensecounts-7396ae99aaab07e29c92b509a6515508fbe68158",
+  "TrainGCNV.gatk_docker": "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.1.8.1",
+  "TrainGCNV.linux_docker": "australia-southeast1-docker.pkg.dev/cpg-common/images/ubuntu1804",
+
+  "TrainGCNV.reference_fasta": "gs://cpg-reference/hg38/v0/Homo_sapiens_assembly38.fasta",
+  "TrainGCNV.reference_index": "gs://cpg-reference/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
+  "TrainGCNV.reference_dict": "gs://cpg-reference/hg38/v0/Homo_sapiens_assembly38.dict",
+
+  "TrainGCNV.ref_copy_number_autosomal_contigs": "2",
+  "TrainGCNV.allosomal_contigs": ["chrX", "chrY"],
+
+  "TrainGCNV.contig_ploidy_priors": "gs://cpg-reference/hg38/v0/sv-resources/resources/v1/hg38.contig_ploidy_priors_homo_sapiens.tsv",
+  "TrainGCNV.num_intervals_per_scatter": "5000",
+  "TrainGCNV.do_explicit_gc_correction": "true",
+  "TrainGCNV.gcnv_enable_bias_factors": "false",
+
+  "TrainGCNV.gcnv_caller_update_convergence_threshold": "0.000001",
+  "TrainGCNV.gcnv_model_cnv_coherence_length": "1000",
+  "TrainGCNV.gcnv_convergence_snr_trigger_threshold": "0.2",
+  "TrainGCNV.gcnv_interval_psi_scale": "0.05",
+  "TrainGCNV.ploidy_mean_bias_standard_deviation": "1",
+
+  "TrainGCNV.gcnv_depth_correction_tau": "10000",
+  "TrainGCNV.gcnv_log_emission_sampling_median_rel_error": "0.001",
+
+  "TrainGCNV.gcnv_model_learning_rate": "0.03",
+  "TrainGCNV.gcnv_model_num_thermal_advi_iters": "2500",
+  "TrainGCNV.gcnv_model_max_advi_iter_first_epoch": "5000",
+  "TrainGCNV.gcnv_model_max_advi_iter_subsequent_epochs": "200",
+  "TrainGCNV.gcnv_model_max_training_epochs": "50",
+  "TrainGCNV.gcnv_model_min_training_epochs": "5",
+  "TrainGCNV.gcnv_model_convergence_snr_averaging_window": "500",
+  "TrainGCNV.gcnv_model_convergence_snr_countdown_window": "10",
+  "TrainGCNV.gcnv_model_cnv_coherence_length": "1000",
+
+  "TrainGCNV.gcnv_learning_rate" : 0.03,
+  "TrainGCNV.gcnv_num_thermal_advi_iters": "250",
+  "TrainGCNV.gcnv_max_advi_iter_first_epoch": "5000",
+  "TrainGCNV.gcnv_max_advi_iter_subsequent_epochs": "200",
+  "TrainGCNV.gcnv_max_training_epochs": "50",
+  "TrainGCNV.gcnv_min_training_epochs": "5",
+  "TrainGCNV.gcnv_convergence_snr_averaging_window": "100",
+  "TrainGCNV.gcnv_convergence_snr_countdown_window" : "10",
+  "TrainGCNV.gcnv_cnv_coherence_length" : "1000",
+  "TrainGCNV.gcnv_copy_number_posterior_expectation_mode": "EXACT",
+
+  "TrainGCNV.gcnv_log_emission_sampling_rounds" : "20",
+  "TrainGCNV.gcnv_p_alt" : "0.000001",
+  "TrainGCNV.gcnv_sample_psi_scale" : "0.000001",
+  "TrainGCNV.ploidy_sample_psi_scale" : "0.001"
+
+}
+


### PR DESCRIPTION
Seems to be working on a batch of 96 samples. In addition to the `TrainGCNV_inputs.json` file below, we feed the analysis-runner with:

```
"inputs_dict": {
  "TrainGCNV.cohort": "tob96",
  "TrainGCNV.samples": ["<array of sample IDs>"],
  "TrainGCNV.count_files": ["<array of paths to their counts.tsv.gz file>"]
  }
```
