### PR TITLE
Use old pipe

### DIFF
--- a/gatk-sv/scripts/docker_sync.R
+++ b/gatk-sv/scripts/docker_sync.R
@@ -28,7 +28,7 @@ d <- gatk_sv_json %>%
   unnest(us_gcr) %>%
   filter(!image_name %in% c("name", "melt_docker", "cloud_sdk_docker", "linux_docker")) %>%
   mutate(bname = basename(us_gcr)) %>%
-  select(us_gcr, bname) |>
+  select(us_gcr, bname) %>%
   distinct()
 
 # copy to AU AR


### PR DESCRIPTION
`|>` can be used only with R > 4.1
We should probably update the analysis-runner driver `r-base` to v4.1. Not urgent :-)