### PR TITLE
Pure repeats pr review

### DIFF
--- a/str/inputs/pure_repeats_catalog/bed_to_fasta.py
+++ b/str/inputs/pure_repeats_catalog/bed_to_fasta.py
@@ -28,9 +28,13 @@ catalog = b.read_input(CATALOG_PATH)
 fasta = b.read_input(REF_FASTA)
 
 # set the job command
-bedtools_job.command(f'bedtools getfasta -fi {fasta} -bed {catalog} > {bedtools_job.ofile}')
+bedtools_job.command(
+    f'bedtools getfasta -fi {fasta} -bed {catalog} > {bedtools_job.ofile}'
+)
 
 # write output to GCP bucket for this dataset
-b.write_output(bedtools_job.ofile, output_path('catalog_fasta_sequences.fasta', 'analysis'))
+b.write_output(
+    bedtools_job.ofile, output_path('catalog_fasta_sequences.fasta', 'analysis')
+)
 
 b.run(wait=False)

--- a/str/inputs/pure_repeats_catalog/bed_to_fasta.py
+++ b/str/inputs/pure_repeats_catalog/bed_to_fasta.py
@@ -3,63 +3,34 @@
 """
 Converts coordinates in BED file to FASTA sequence
 """
-import os
-import hailtop.batch as hb
-import click
-
 from cpg_utils.config import get_config
+from cpg_utils.hail_batch import output_path
+from cpg_workflows.batch import get_batch
 
-from cpg_utils.hail_batch import (
-    remote_tmpdir,
-)
-
-config = get_config()
-DATASET = os.getenv('DATASET')
-HAIL_BUCKET = os.getenv('HAIL_BUCKET')
-OUTPUT_SUFFIX = os.getenv('OUTPUT')
-BILLING_PROJECT = os.getenv('HAIL_BILLING_PROJECT')
-ACCESS_LEVEL = os.getenv('ACCESS_LEVEL')
 
 CATALOG_PATH = (
     'gs://cpg-tob-wgs-test/hoptan-str/bed_catalog_without_complex_repeats.bed.txt'
 )
-BEDTOOLS_IMAGE = (
-    'australia-southeast1-docker.pkg.dev/cpg-common/images/bedtools:v2.30.0'
-)
 REF_FASTA = 'gs://cpg-common-main/references/hg38/v0/Homo_sapiens_assembly38.fasta'
 
 
-@click.command()
-def main():  # pylint: disable=missing-function-docstring
+# Initializing Batch
+b = get_batch('FASTA conversion')
 
-    # Initializing Batch
-    backend = hb.ServiceBackend(
-        billing_project=get_config()['hail']['billing_project'],
-        remote_tmpdir=remote_tmpdir(),
-    )
-    b = hb.Batch(backend=backend, default_image=os.getenv('DRIVER_IMAGE'))
-    bedtools_job = b.new_job(name=f'Get sequence data for FASTA files')
-    catalog = b.read_input(CATALOG_PATH)
-    fasta = b.read_input(REF_FASTA)
-    bedtools_job.image(BEDTOOLS_IMAGE)
-    bedtools_job.storage('20G')
-    bedtools_job.cpu(8)
+# provision a new job
+bedtools_job = b.new_job(name=f'Get sequence data for FASTA files')
+bedtools_job.image(get_config()['images']['bedtools'])
+bedtools_job.storage('20G')
+bedtools_job.cpu(8)
 
-    bedtools_job.command(
-        f"""
+# read input files
+catalog = b.read_input(CATALOG_PATH)
+fasta = b.read_input(REF_FASTA)
 
-        bedtools getfasta -fi {fasta} -bed {catalog} > {bedtools_job.ofile}
-        
-        """
-    )
+# set the job command
+bedtools_job.command(f'bedtools getfasta -fi {fasta} -bed {catalog} > {bedtools_job.ofile}')
 
-    # Output writing
-    out_fname = f'catalog_fasta_sequences.fasta'
-    output_path = f'gs://cpg-tob-wgs-test/hoptan-str/{out_fname}'
-    b.write_output(bedtools_job.ofile, output_path)
+# write output to GCP bucket for this dataset
+b.write_output(bedtools_job.ofile, output_path('catalog_fasta_sequences.fasta', 'analysis'))
 
-    b.run(wait=False)
-
-
-if __name__ == '__main__':
-    main()
+b.run(wait=False)

--- a/str/inputs/pure_repeats_catalog/pure_repeats_script.py
+++ b/str/inputs/pure_repeats_catalog/pure_repeats_script.py
@@ -37,7 +37,7 @@ sections = []
 with open(TRF_DATA, encoding='utf-8') as filehandle:
 
     # start a fresh section
-    this_section = []
+    this_section: list[str] = []
 
     # iterate over lines in this file
     for line in filehandle:

--- a/str/inputs/pure_repeats_catalog/pure_repeats_script.py
+++ b/str/inputs/pure_repeats_catalog/pure_repeats_script.py
@@ -1,0 +1,77 @@
+"""
+script alternative to the ipython notebook code
+"""
+
+
+import sys
+import csv
+import json
+import re
+
+
+TRF_DATA = 'trf_output.dat'
+SEQUENCE = 'Sequence:'
+PARAMETERS = 'Parameters:'
+
+# indices
+PURITY_INDEX = 5
+REPEAT_INDEX = 13
+
+
+def get_purest_motif(metric_list: list[str]) -> tuple[str, int]:
+    """
+    take the list of metrics lines, find the purest
+    wasteful if there's only one row
+    :param metric_list:
+    :return:
+    """
+    metric_data = []
+    for each_metric in metric_list:
+        line_list = each_metric.rstrip().split()
+        metric_data.append((line_list[REPEAT_INDEX], int(line_list[PURITY_INDEX])))
+
+    return max(metric_data, key=lambda x: x[1])
+
+
+sections = []
+
+# parse the file into sections, broken up by 'Sequence:' lines
+with open(sys.argv[1]) as filehandle:
+
+    this_section = []
+    for line in filehandle:
+        if line.startswith(SEQUENCE):
+            # avoid storing the header
+            if any(section_line.startswith(SEQUENCE) for section_line in this_section):
+                sections.append(this_section)
+
+            # reset the section
+            this_section = []
+
+        # ignore blank lines
+        if line.rstrip():
+            this_section.append(line.rstrip())
+
+    sections.append(this_section)
+
+blank_coords = []
+pure_repeats = []
+
+# process the sections:
+for section in sections:
+    # if there were no metrics - get the blank coordinates
+    if len(section) == 2:
+        blank_coords.append(section[0].removeprefix(SEQUENCE).rstrip())
+        continue
+
+    # otherwise get the purest repeat, and the purity score
+    # not interested in parameters?
+    this_seq = section[0].removeprefix(SEQUENCE).rstrip()
+    motif, purity = get_purest_motif(section[2:])
+    if purity == 100:
+        pure_repeats.append((this_seq, motif, purity))
+
+
+print(len(blank_coords))  # 6409
+print(len(pure_repeats))  # 161612
+

--- a/str/inputs/pure_repeats_catalog/pure_repeats_script.py
+++ b/str/inputs/pure_repeats_catalog/pure_repeats_script.py
@@ -131,5 +131,5 @@ for blank in blank_coords:
 
 print(len(pure_repeats))
 
-with open('output.txt', 'w') as handle:
+with open('output.txt', 'w', encoding='utf-8') as handle:
     handle.writelines('\n'.join(['\t'.join(pure) for pure in pure_repeats]))

--- a/str/inputs/pure_repeats_catalog/pure_repeats_script.py
+++ b/str/inputs/pure_repeats_catalog/pure_repeats_script.py
@@ -18,8 +18,9 @@ def get_purest_motif(metric_list: list[str]) -> tuple[str, int]:
     """
     take the list of metrics lines, find the purest
     wasteful if there's only one row
+    allows for multiple motifs at one locus
     :param metric_list:
-    :return:
+    :return: the purest motif and assc. purity
     """
     metric_data = []
     for each_metric in metric_list:
@@ -32,29 +33,38 @@ def get_purest_motif(metric_list: list[str]) -> tuple[str, int]:
 sections = []
 
 # parse the file into sections, broken up by 'Sequence:' lines
+# each 'section' will contain the sequence, params, and metrics lines
 with open(TRF_DATA, encoding='utf-8') as filehandle:
 
+    # start a fresh section
     this_section = []
+
+    # iterate over lines in this file
     for line in filehandle:
+
+        # demarcates a new sequence, so add the old
         if line.startswith(SEQUENCE):
             # avoid storing the header
             if any(section_line.startswith(SEQUENCE) for section_line in this_section):
                 sections.append(this_section)
 
-            # reset the section
-            this_section = []
+            # reset the section - adding this line
+            this_section = [line.rstrip()]
 
-        # ignore blank lines
-        if line.rstrip():
+        # ignore blank lines, but keep adding to the existing section
+        elif line.rstrip():
             this_section.append(line.rstrip())
 
+    # after iterating over the file, catch the final section
     sections.append(this_section)
+
 
 blank_coords = []
 pure_repeats = []
 
-# process the sections:
+# process the sections
 for section in sections:
+
     # if there were no metrics - get the blank coordinates
     if len(section) == 2:
         blank_coords.append(section[0].removeprefix(SEQUENCE).rstrip())
@@ -68,6 +78,7 @@ for section in sections:
         pure_repeats.append((this_seq, motif))
 
 
+# debug
 print(len(blank_coords))  # 6409
 print(len(pure_repeats))  # 161612
 
@@ -96,15 +107,18 @@ with open('catalog_fasta_sequences.fasta.txt', encoding='utf-8') as handle:
     fasta_lines = handle.readlines()
 
 fasta_dict = {}
-# iterate over lines in pairs
-# not efficient, but whatever
+# iterate over lines in pairs. not efficient, but whatever
+# would need re-thinking if the motifs stretched to multiple lines
 for line_pair in chunks(fasta_lines, 2):
     assert line_pair[0].startswith(FASTA_START)
     fasta_dict[line_pair[0].lstrip(FASTA_START).rstrip()] = line_pair[1].rstrip()
 
+
+# debug
 print(fasta_dict["chr12:6936716-6936773"])
 print(motif_dictionary["chr12:6936716-6936773"])
 
+# check if any of the impure repeats can be recovered
 impure_repeats = []
 for blank in blank_coords:
     motif = motif_dictionary[blank]

--- a/str/inputs/pure_repeats_catalog/pure_repeats_script.py
+++ b/str/inputs/pure_repeats_catalog/pure_repeats_script.py
@@ -115,8 +115,8 @@ for line_pair in chunks(fasta_lines, 2):
 
 
 # debug
-print(fasta_dict["chr12:6936716-6936773"])
-print(motif_dictionary["chr12:6936716-6936773"])
+print(fasta_dict['chr12:6936716-6936773'])
+print(motif_dictionary['ßchr12:6936716-6936773'])
 
 # check if any of the impure repeats can be recovered
 impure_repeats = []


### PR DESCRIPTION
2 things here 

- The hail script - there are many CPG helper methods so you don't need to handle the batch setup process manually, the `get_batch()` method sets up a batch according to the config settings in the environment (which analysis runner will set, happy to explain more on this). This just means that you can run the same process with far less wrapper code 👍 
- The other is the ipynb for analysing TRF data. The original contains a lot of iterating over lines by index and storing line indices to revisit etc - I think there are a lot of shortcuts available in python to directly iterate over lines in a file which are more intuitive. I've altered the output here to store both the coordinates and the corresponding motif used (e.g. where there are multiple motifs available at a locus). This would be super easy to adapt

Don't feel obliged to use any of this; other than the multi-metric parsing I expect these scripts to be functionally identical