### PR TITLE
SPEED

### DIFF
--- a/str/sensitivity-analysis/capillary_genotypes.py
+++ b/str/sensitivity-analysis/capillary_genotypes.py
@@ -1,57 +1,74 @@
 import warnings
+
+
 warnings.simplefilter(action='ignore', category=FutureWarning)
-import pandas as pd 
-
-file = open("combinedmicrosats_627loci_1048indivs_numRpts.stru.txt")
-file = file.readlines()
-
-loci = file[0].split()
-print(len(loci)) #627
-
-motif_length = file[1].split()
-print(len(motif_length)) #627
-
-num_str_regions = file[2].split()
-print(len(num_str_regions)) #627 
-
-repeat_regularity = file[3].split()
-
-loci_dict={}
-i = 0
-while i<len(loci):
-    loci_dict[ loci[i]] = (motif_length[i], num_str_regions[i],repeat_regularity[i])
-    i+=1
-
-j=4 #start of genotype read outs 
-df_main = pd.DataFrame(columns = ['sample_id', 'locus_id', 'genotype', 'population_id', 'population_name', 'geographic_population', 'predefined_region', 'regularity', 'motif_length'])
-
-while j<len(file): 
-    attributes = file[j].split()
-    sample_id = attributes[0]
-    population_id = attributes[1]
-    population_name = attributes[2]
-    geographic_population = attributes[3]
-    predefined_region = attributes[4]
-    k = 0 
-    while k<627:
-        motif_length, num_str_regions,repeat_regularity = loci_dict[loci[k]]
-        df_temp = pd.DataFrame({
-            'sample_id': [sample_id],
-            'locus_id': [loci[k]],
-            'genotype':[attributes[5+k]],
-            'population_id': [population_id],
-            'population_name': [population_name],
-            'geographic_population': [geographic_population],
-            'predefined_region': [predefined_region] ,
-            'regularity': [repeat_regularity],
-            'motif_length':[motif_length]
-         })
-        df_main = df_main.append(df_temp)
-        k+=1
-    j+=1
-    print(j)
-df_main.to_csv("capillary_genotypes.csv", index = False)
 
 
+file = open("combinedmicrosats_627loci_1048indivs_numRpts.stru")
+# file = file.readlines()
 
+loci = file.readline().rstrip().split()
+# print(len(loci)) #627
 
+motif_length = file.readline().rstrip().split()
+# print(len(motif_length)) #627
+
+num_str_regions = file.readline().rstrip().split()
+# print(len(num_str_regions)) #627
+
+repeat_regularity = file.readline().rstrip().split()
+
+loci_dict = {
+    locus: (motif_len, num_str, regularity)
+    for locus, motif_len, num_str, regularity in zip(
+        loci, motif_length, num_str_regions, repeat_regularity
+    )
+}
+
+# print(loci_dict)
+
+with open("capillary_genotypes.csv", 'w', encoding='utf-8') as handle:
+    handle.write(
+        ','.join(
+            [
+                'sample_id',
+                'locus_id',
+                'genotype',
+                'population_id',
+                'population_name',
+                'geographic_population',
+                'predefined_region',
+                'regularity',
+                'motif_length',
+            ]
+        )
+        + '\n'
+    )
+
+    for line in file:
+        attributes = line.split()
+        sample_id = attributes[0]
+        population_id = attributes[1]
+        population_name = attributes[2]
+        geographic_population = attributes[3]
+        predefined_region = attributes[4]
+
+        for i, locus in enumerate(loci):
+
+            motif_length, num_str_regions, repeat_regularity = loci_dict[locus]
+            handle.write(
+                ','.join(
+                    [
+                        sample_id,
+                        locus,
+                        attributes[5 + i],
+                        population_id,
+                        population_name,
+                        geographic_population,
+                        predefined_region,
+                        repeat_regularity,
+                        motif_length,
+                    ]
+                )
+                + '\n'
+            )

--- a/str/sensitivity-analysis/capillary_genotypes.py
+++ b/str/sensitivity-analysis/capillary_genotypes.py
@@ -1,7 +1,22 @@
 import warnings
+from itertools import chain, islice
 
 
 warnings.simplefilter(action='ignore', category=FutureWarning)
+
+
+def generator_chunks(generator, size):
+    """
+    Iterates across a generator, returning specifically sized chunks
+    Args:
+        generator (): any generator or method implementing yield
+        size (): size of iterator to return
+    Returns:
+        a subset of the generator results
+    """
+    iterator = iter(generator)
+    for first in iterator:
+        yield list(chain([first], islice(iterator, size - 1)))
 
 
 file = open("combinedmicrosats_627loci_1048indivs_numRpts.stru")
@@ -33,7 +48,8 @@ with open("capillary_genotypes.csv", 'w', encoding='utf-8') as handle:
             [
                 'sample_id',
                 'locus_id',
-                'genotype',
+                'genotype_1',
+                'genotype_2',
                 'population_id',
                 'population_name',
                 'geographic_population',
@@ -45,13 +61,21 @@ with open("capillary_genotypes.csv", 'w', encoding='utf-8') as handle:
         + '\n'
     )
 
-    for line in file:
-        attributes = line.split()
-        sample_id = attributes[0]
-        population_id = attributes[1]
-        population_name = attributes[2]
-        geographic_population = attributes[3]
-        predefined_region = attributes[4]
+    for line_1, line_2 in generator_chunks(file, 2):
+
+        attributes_1 = line_1.split()
+        attributes_2 = line_2.split()
+        # checks
+        assert attributes_1[:5] == attributes_2[:5]
+
+        sample_id = attributes_1[0]
+        population_id = attributes_1[1]
+        population_name = attributes_1[2]
+        geographic_population = attributes_1[3]
+        predefined_region = attributes_1[4]
+
+        genotypes_1 = attributes_1[5:]
+        genotypes_2 = attributes_2[5:]
 
         for i, locus in enumerate(loci):
 
@@ -61,7 +85,8 @@ with open("capillary_genotypes.csv", 'w', encoding='utf-8') as handle:
                     [
                         sample_id,
                         locus,
-                        attributes[5 + i],
+                        genotypes_1[i],
+                        genotypes_2[i],
                         population_id,
                         population_name,
                         geographic_population,


### PR DESCRIPTION
Removes a few `non-pythonic` inclusions:

* instead of iterating over objects by index, iterate over the object exactly, e.g. instead of a `while k <= len(object); row = object[k]`, just do `for row in object` - much easier to read, mostly foolproof (will just stop looping once there are no more rows), and will work on just about every iterable object type (lists, tuples, dicts, file handlers...)
* Don't store more than you have to - here we have the first 4 lines that we need repeatedly (metadata), but each other line is handled atomically. That means that we don't need to hold it all in memory. Reading all the contents into memory and iterating by index is MUCH slower than reading a file one line at a time, but for this purpose accomplishes the same result.
* Think about your output, and then the easiest way to reach it. In the original you're constructing a pandas dataframe (a 'heavy' object, with a lot of features), then appending to it a million times. This potentially means a million regenerations of an index, and provisioning new memory space for the growing object. Instead of that, just write directly to an output file line by line, with a negligible memory footprint.

This revised script generates ~78MB of output, 1.3M lines, in 0.7 seconds