### PR TITLE
Update str_iterative_eh_runner.py

### DIFF
--- a/str/trtools/merge_str_prep.py
+++ b/str/trtools/merge_str_prep.py
@@ -54,7 +54,9 @@ def main(
 
     input_vcf_dict = {}
 
-    input_vcf_dict = {id: os.path.join(input_dir, f'{id}_{caller}.vcf') for id in internal_wgs_ids}
+    input_vcf_dict = {
+        id: os.path.join(input_dir, f'{id}_{caller}.vcf') for id in internal_wgs_ids
+    }
 
     for id in list(input_vcf_dict.keys()):
         bcftools_job = b.new_job(name=f'{id} {caller} Files prep')


### PR DESCRIPTION
Add max-parallel-jobs option to avoid exceeding Gcloud quotas. - inspiration: https://github.com/populationgenomics/sv-workflows/blob/main/str/tob-wgs/tob_eh_runner.py (now a bit out of date) 