### PR TITLE
Create vcf_combiner.py

### DIFF
--- a/str/helper/vcf_combiner.py
+++ b/str/helper/vcf_combiner.py
@@ -2,7 +2,7 @@
 # pylint: disable=import-error, too-many-locals
 
 """
-This script combines sharded VCFs (from one sample and one caller) into one VCF.
+This script combines sharded ExpansionHunter VCFs (from one sample and one caller) into one VCF.
 
 analysis-runner --access-level test --dataset tob-wgs --description \
     'VCF combiner' --output-dir 'str/5M_run_combined_vcfs' \
@@ -19,7 +19,7 @@ config = get_config()
 
 
 def combine_vcf_files(input_dir, gcs_out_path):
-    """Combines sharded VCFs in input_dir into one combined VCF, writing it to a GCS output path"""
+    """Combines sharded ExpansionHunter VCFs in input_dir into one combined VCF, writing it to a GCS output path"""
     input_files = to_path(input_dir).glob('*.vcf')
 
     # Initialize variables to store information

--- a/str/helper/vcf_combiner.py
+++ b/str/helper/vcf_combiner.py
@@ -29,10 +29,10 @@ def combine_vcf_files(input_dir, gcs_out_path):
     chrom_line = ''
     gt_lines = []
 
-    shard_counter =0
+    shard_counter = 0
     # Process each input file
     for file_index, input_file in enumerate(input_files):
-        shard_counter= shard_counter+1
+        shard_counter = shard_counter + 1
         with to_path(input_file).open() as f:
             for line in f:
                 # Collect information from the header lines

--- a/str/helper/vcf_combiner.py
+++ b/str/helper/vcf_combiner.py
@@ -7,7 +7,7 @@ This script combines sharded VCFs (from one sample and one caller) into one VCF.
 analysis-runner --access-level test --dataset tob-wgs --description \
     'VCF combiner' --output-dir 'str/5M_run_combined_vcfs' \
     vcf_combiner.py \
-    --input-dir=gs://cpg-tob-wgs-main-analysis/str/5M_run/CPG308288 \
+    --input-dir=gs://cpg-tob-wgs-test/hoptan-str/sharded_tester
 """
 import click
 
@@ -78,7 +78,7 @@ def main(input_dir):
 
     combiner_job = b.new_python_job(name=f'VCF Combiner job: {cpg_id}')
 
-    out_path = output_path(f'{cpg_id}_combined.vcf')
+    out_path = output_path(f'{cpg_id}_combined.vcf', 'analysis')
     combiner_job.call(combine_vcf_files, input_dir, out_path)
 
     b.run(wait=False)

--- a/str/helper/vcf_combiner.py
+++ b/str/helper/vcf_combiner.py
@@ -31,6 +31,7 @@ def combine_vcf_files(input_dir, gcs_out_path):
 
     # Process each input file
     for file_index, input_file in enumerate(input_files):
+        print(f'Parsing {input_file}')
         with to_path(input_file).open() as f:
             for line in f:
                 # Collect information from the header lines

--- a/str/helper/vcf_combiner.py
+++ b/str/helper/vcf_combiner.py
@@ -52,7 +52,7 @@ def combine_vcf_files(input_dir, gcs_out_path):
                     gt_lines.append(line)
 
     # Sort ALT lines alphabetically and convert to a list
-    sorted_alt_lines = sorted(list(alt_lines))
+    sorted_alt_lines = sorted(alt_lines)
 
     # Write the combined information to the output file
     with to_path(gcs_out_path).open('w') as out_file:

--- a/str/helper/vcf_combiner.py
+++ b/str/helper/vcf_combiner.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# pylint: disable=import-error, too-many-locals
 
 """
 This script combines sharded ExpansionHunter VCFs (from one sample and one caller) into one VCF.
@@ -9,7 +8,7 @@ analysis-runner --access-level test --dataset tob-wgs --description \
     'VCF combiner' --output-dir 'str/5M_run_combined_vcfs' \
     vcf_combiner.py \
     --input-dir=gs://cpg-tob-wgs-test/hoptan-str/sharded_tester \
-    CPGXXXX  CPGXXX
+    CPGXXXX CPGXXX
 """
 import click
 

--- a/str/helper/vcf_combiner.py
+++ b/str/helper/vcf_combiner.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# pylint: disable=import-error, too-many-locals
+
+"""
+This script combines sharded VCFs (from one sample and one caller) into one VCF.
+
+analysis-runner --access-level test --dataset tob-wgs --description \
+    'VCF combiner' --output-dir 'str/5M_run_combined_vcfs' \
+    vcf_combiner.py \
+    --input-dir=gs://cpg-tob-wgs-main-analysis/str/5M_run/CPG308288 \
+"""
+import click
+import sys
+
+from cpg_utils.config import get_config
+from cpg_utils import to_path
+from cpg_utils.hail_batch import get_batch, output_path
+
+config = get_config()
+
+def combine_vcf_files(input_dir, gcs_out_path):
+    input_files  = to_path(input_dir).glob('*.vcf')
+
+    # Initialize variables to store information
+    fileformat_line = ""
+    info_lines = []
+    alt_lines = set()
+    chrom_line = ""
+    gt_lines = []
+
+    # Process each input file
+    for file_index, input_file in enumerate(input_files):
+        with to_path(input_file).open() as f:
+            for line in f:
+                # Collect information from the header lines
+                if line.startswith('##fileformat') and file_index == 0:
+                    fileformat_line = line
+                elif (line.startswith('##INFO') or line.startswith('##FILTER') or line.startswith('##FORMAT')) and file_index == 0:
+                    info_lines.append(line)
+                elif line.startswith('##ALT'):
+                    # Collect ALT lines from all files into a set to remove duplicates
+                    alt_lines.add(line)
+                elif line.startswith('#CHROM') and file_index == 0:
+                    chrom_line = line
+                else:
+                    # Collect calls after #CHROM
+                    gt_lines.append(line)
+
+    # Sort ALT lines alphabetically and convert to a list
+    sorted_alt_lines = sorted(list(alt_lines))
+
+    # Write the combined information to the output file
+    with to_path(gcs_out_path).open('w') as out_file:
+        # Write fileformat line
+        out_file.write(fileformat_line)
+        # Write INFO, FILTER, and FORMAT lines
+        out_file.writelines(info_lines)
+        # Write ALT lines
+        out_file.writelines(sorted_alt_lines)
+        # Write CHROM line
+        out_file.write(chrom_line)
+        # Write GT or lines containing the calls
+        out_file.writelines(gt_lines)
+
+
+@click.command()
+@click.option('--input-dir',help='Input directory for sharded VCFs')
+
+def main(
+    input_dir
+):
+    # pylint: disable=missing-function-docstring
+    # Initializing Batch
+    b = get_batch()
+    cpg_id = input_dir.split('/')[-1]
+
+    combiner_job = b.new_python_job(name=f'VCF Combiner job: {cpg_id}')
+
+    out_path = output_path(f'{cpg_id}_combined.vcf')
+    combiner_job.call(combine_vcf_files, input_dir, out_path)
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/str/helper/vcf_combiner.py
+++ b/str/helper/vcf_combiner.py
@@ -10,7 +10,6 @@ analysis-runner --access-level test --dataset tob-wgs --description \
     --input-dir=gs://cpg-tob-wgs-main-analysis/str/5M_run/CPG308288 \
 """
 import click
-import sys
 
 from cpg_utils.config import get_config
 from cpg_utils import to_path
@@ -18,14 +17,16 @@ from cpg_utils.hail_batch import get_batch, output_path
 
 config = get_config()
 
+
 def combine_vcf_files(input_dir, gcs_out_path):
-    input_files  = to_path(input_dir).glob('*.vcf')
+    """Combines sharded VCFs in input_dir into one combined VCF, writing it to a GCS output path"""
+    input_files = to_path(input_dir).glob('*.vcf')
 
     # Initialize variables to store information
-    fileformat_line = ""
+    fileformat_line = ''
     info_lines = []
     alt_lines = set()
-    chrom_line = ""
+    chrom_line = ''
     gt_lines = []
 
     # Process each input file
@@ -35,7 +36,11 @@ def combine_vcf_files(input_dir, gcs_out_path):
                 # Collect information from the header lines
                 if line.startswith('##fileformat') and file_index == 0:
                     fileformat_line = line
-                elif (line.startswith('##INFO') or line.startswith('##FILTER') or line.startswith('##FORMAT')) and file_index == 0:
+                elif (
+                    line.startswith('##INFO')
+                    or line.startswith('##FILTER')
+                    or line.startswith('##FORMAT')
+                ) and file_index == 0:
                     info_lines.append(line)
                 elif line.startswith('##ALT'):
                     # Collect ALT lines from all files into a set to remove duplicates
@@ -64,11 +69,8 @@ def combine_vcf_files(input_dir, gcs_out_path):
 
 
 @click.command()
-@click.option('--input-dir',help='Input directory for sharded VCFs')
-
-def main(
-    input_dir
-):
+@click.option('--input-dir', help='Input directory for sharded VCFs')
+def main(input_dir):
     # pylint: disable=missing-function-docstring
     # Initializing Batch
     b = get_batch()

--- a/str/helper/vcf_combiner.py
+++ b/str/helper/vcf_combiner.py
@@ -29,9 +29,10 @@ def combine_vcf_files(input_dir, gcs_out_path):
     chrom_line = ''
     gt_lines = []
 
+    shard_counter =0
     # Process each input file
     for file_index, input_file in enumerate(input_files):
-        print(f'Parsing {input_file}')
+        shard_counter= shard_counter+1
         with to_path(input_file).open() as f:
             for line in f:
                 # Collect information from the header lines
@@ -52,6 +53,7 @@ def combine_vcf_files(input_dir, gcs_out_path):
                     # Collect calls after #CHROM
                     gt_lines.append(line)
 
+    print(f'Parsed {shard_counter} sharded VCFs')
     # Sort ALT lines alphabetically and convert to a list
     sorted_alt_lines = sorted(alt_lines)
 


### PR DESCRIPTION
EH 5M loci run was done using 50 sharded subcatalogs, meaning that each sample has 50 sharded VCFs. 
This script combines the 50 sharded VCFs into one combined VCF (ie each sample will have one combined VCF for downstream use). 

This script assumes that the 
- ##fileformat, ##FORMAT, ##INFO, ##FILTER lines are constant across all sharded VCFs, and therefore extracts these lines from the first shard to write to output. 
- ##ALT lines are collected as a set across all sharded VCFs (set structure removes duplicates), and then sorted alphabetically to be written to output. 
-  remaining lines are calls (genotypes) at each locus, and are added sequentially to the output file. [VCF sort is run as a downstream step of the pipeline so no need to sort the loci by coordinates now]. 