### PR TITLE
Create bcftools_merge_runner.py

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -19,7 +19,8 @@
 # 12. redefined-builtin
 # 13. arguments-renamed
 # 14. import-error
-# 14. R0801: Similar lines in 2 files/duplicate-code
+# 15. R0801: Similar lines in 2 files/duplicate-code
+# 16. unsubscriptable-object
 #
 # The following require installing the python modules imported in the source code.
 #    Add these if you don't want to include all dependencies into the dev environment:
@@ -27,7 +28,7 @@
 #    no-member
 #    c-extension-no-member
 #
-disable=f-string-without-interpolation,inherit-non-class,too-few-public-methods,fixme,logging-fstring-interpolation,trailing-whitespace,use-dict-literal,too-many-instance-attributes,line-too-long,no-else-return,redefined-builtin,arguments-renamed,import-error,R0801
+disable=f-string-without-interpolation,inherit-non-class,too-few-public-methods,fixme,logging-fstring-interpolation,trailing-whitespace,use-dict-literal,too-many-instance-attributes,line-too-long,no-else-return,redefined-builtin,arguments-renamed,import-error,R0801,unsubscriptable-object
 
 # Overriding variable name patterns to allow short 1- or 2-letter variables
 attr-rgx=[a-z_][a-z0-9_]{0,30}$

--- a/str/trtools/bcftools_merge_runner.py
+++ b/str/trtools/bcftools_merge_runner.py
@@ -23,8 +23,11 @@ BCFTOOLS_IMAGE = config['images']['bcftools']
 @click.option('--input-dir', help='gs://...')
 # input sample ID
 @click.argument('internal-wgs-ids', nargs=-1)
+@click.option(
+    '--job-storage', help='Storage of the Hail batch job eg 30G', default='50G'
+)
 @click.command()
-def main(input_dir, internal_wgs_ids: list[str]):
+def main(input_dir, job_storage, internal_wgs_ids: list[str]):
     """Merge sample VCFs using bcftools merge"""
 
     # Initializing Batch
@@ -47,7 +50,7 @@ def main(input_dir, internal_wgs_ids: list[str]):
     bcftools_job = b.new_job(name=f'Bcftools merge job')
     bcftools_job.image(BCFTOOLS_IMAGE)
     bcftools_job.cpu(4)
-    bcftools_job.storage('20G')
+    bcftools_job.storage(job_storage)
 
     bcftools_job.declare_resource_group(vcf_out={'vcf.gz': '{root}.vcf.gz'})
     bcftools_job.command(

--- a/str/trtools/bcftools_merge_runner.py
+++ b/str/trtools/bcftools_merge_runner.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# pylint: disable=duplicate-code
+"""
+This script merges ExpansionHunter VCFs together into one VCF using `bcftools merge`
+Required input: --input-dir and external sample IDs
+For example:
+analysis-runner --access-level standard --dataset tob-wgs --description 'bcftools merge test ' --output-dir 'str/5M_run_combined_vcfs/bcftools_merge/v4-3' bcftools_merge_runner.py --input-dir=gs://cpg-tob-wgs-main-analysis/str/5M_run_combined_vcfs/v4 CPGtestersorted2
+
+Required packages: sample-metadata, hail, click, os
+pip install sample-metadata hail click
+
+"""
+import os
+import click
+
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import get_batch, output_path, reference_path
+
+config = get_config()
+
+REF_FASTA = str(reference_path('broad/ref_fasta'))
+BCFTOOLS_IMAGE = config['images']['bcftools']
+
+
+# inputs:
+# input directory
+@click.option('--input-dir', help='gs://...')
+# input sample ID
+@click.argument('internal-wgs-ids', nargs=-1)
+@click.command()
+def main(
+    input_dir, internal_wgs_ids: list[str]
+):  # pylint: disable=missing-function-docstring
+    # Initializing Batch
+    b = get_batch()
+
+    # Working with CRAM files requires the reference fasta
+    ref = b.read_input_group(
+        **dict(
+            base=REF_FASTA,
+            fai=REF_FASTA + '.fai',
+            dict=REF_FASTA.replace('.fasta', '').replace('.fna', '').replace('.fa', '')
+            + '.dict',
+        )
+    )
+
+    # read in input file paths
+    vcffuse_path = []
+    for id in list(internal_wgs_ids):
+        vcf = os.path.join(input_dir, f'{id}_eh.reheader.vcf.gz')
+        suffix = vcf.removeprefix('gs://').split('/', maxsplit=1)[1]
+        vcffuse_path.append(f'/vcffuse/{suffix}')
+    num_samples = len(vcffuse_path)
+    vcffuse_path = ' '.join(vcffuse_path)  # string format for input into bcftools merge
+
+
+    bcftools_job = b.new_job(name=f'Bcftools merge job')
+    bcftools_job.image(BCFTOOLS_IMAGE)
+    bcftools_job.cpu(4)
+    bcftools_job.storage('15G')
+
+
+    bcftools_job.declare_resource_group(
+        vcf_out={
+            'vcf.gz': '{root}.vcf.gz'
+                            }
+    )
+    bcftools_job.command(
+        f"""
+
+        bcftools merge -m both -o {bcftools_job.vcf_out} -O z --threads 4 {vcffuse_path}
+
+        """
+    )
+    # Output writing
+    output_path_eh = output_path(f'{id}_eh', 'analysis')
+    b.write_output(bcftools_job.vcf_sorted, output_path_eh)
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/str/trtools/bcftools_merge_runner.py
+++ b/str/trtools/bcftools_merge_runner.py
@@ -2,12 +2,9 @@
 # pylint: disable=duplicate-code,unsubscriptable-object
 """
 This script merges ExpansionHunter VCFs together into one VCF using `bcftools merge`
-Required input: --input-dir and external sample IDs
+Required input: --input-dir and internal sample CPG IDs
 For example:
-analysis-runner --access-level standard --dataset tob-wgs --description 'bcftools merge test' --output-dir 'str/5M_run_combined_vcfs/bcftools_merge/v4-3' bcftools_merge_runner.py --input-dir=gs://cpg-tob-wgs-main-analysis/str/5M_run_combined_vcfs/v4 CPGtestersorted2
-
-Required packages: sample-metadata, hail, click, os
-pip install sample-metadata hail click
+analysis-runner --access-level standard --dataset tob-wgs --description 'bcftools merge test' --output-dir 'str/5M_run_combined_vcfs/bcftools_merge/v4-3' bcftools_merge_runner.py --input-dir=gs://cpg-tob-wgs-main-analysis/str/5M_run_combined_vcfs/v4 CPGX CPGY
 
 """
 import os
@@ -20,7 +17,6 @@ config = get_config()
 
 BCFTOOLS_IMAGE = config['images']['bcftools']
 
-
 # inputs:
 # input directory
 @click.option('--input-dir', help='gs://...')
@@ -29,7 +25,9 @@ BCFTOOLS_IMAGE = config['images']['bcftools']
 @click.command()
 def main(
     input_dir, internal_wgs_ids: list[str]
-):  # pylint: disable=missing-function-docstring
+):
+    """ Merge sample VCFs using bcftools merge """
+
     # Initializing Batch
     b = get_batch()
 

--- a/str/trtools/bcftools_merge_runner.py
+++ b/str/trtools/bcftools_merge_runner.py
@@ -4,7 +4,7 @@
 This script merges ExpansionHunter VCFs together into one VCF using `bcftools merge`
 Required input: --input-dir and external sample IDs
 For example:
-analysis-runner --access-level standard --dataset tob-wgs --description 'bcftools merge test ' --output-dir 'str/5M_run_combined_vcfs/bcftools_merge/v4-3' bcftools_merge_runner.py --input-dir=gs://cpg-tob-wgs-main-analysis/str/5M_run_combined_vcfs/v4 CPGtestersorted2
+analysis-runner --access-level standard --dataset tob-wgs --description 'bcftools merge test' --output-dir 'str/5M_run_combined_vcfs/bcftools_merge/v4-3' bcftools_merge_runner.py --input-dir=gs://cpg-tob-wgs-main-analysis/str/5M_run_combined_vcfs/v4 CPGtestersorted2
 
 Required packages: sample-metadata, hail, click, os
 pip install sample-metadata hail click

--- a/str/trtools/bcftools_merge_runner.py
+++ b/str/trtools/bcftools_merge_runner.py
@@ -4,7 +4,7 @@
 This script merges ExpansionHunter VCFs together into one VCF using `bcftools merge`
 Required input: --input-dir and internal sample CPG IDs
 For example:
-analysis-runner --access-level standard --dataset tob-wgs --description 'bcftools merge test' --output-dir 'str/5M_run_combined_vcfs/bcftools_merge/v4-3' bcftools_merge_runner.py --input-dir=gs://cpg-tob-wgs-main-analysis/str/5M_run_combined_vcfs/v4 CPGX CPGY
+analysis-runner --access-level test --dataset tob-wgs --description 'bcftools merge test' --output-dir 'str/5M_run_combined_vcfs/bcftools_merge/v4-2' bcftools_merge_runner.py --input-dir=gs://cpg-tob-wgs-test/str/5M_run_combined_vcfs/merge_str_prep/v4-2 CPG308486 CPG308288
 
 """
 import os
@@ -59,7 +59,7 @@ def main(input_dir, internal_wgs_ids: list[str]):
     )
     # Output writing
     output_path_eh = output_path(f'merged_{num_samples}_eh', 'analysis')
-    b.write_output(bcftools_job.vcf_sorted, output_path_eh)
+    b.write_output(bcftools_job.vcf_out, output_path_eh)
 
     b.run(wait=False)
 

--- a/str/trtools/bcftools_merge_runner.py
+++ b/str/trtools/bcftools_merge_runner.py
@@ -39,12 +39,12 @@ def main(
             'vcf.gz': each_vcf,
             'vcf.gz.tbi': f'{each_vcf}.tbi',
         })['vcf.gz'])
-
+    num_samples = len(internal_wgs_ids)
 
     bcftools_job = b.new_job(name=f'Bcftools merge job')
     bcftools_job.image(BCFTOOLS_IMAGE)
     bcftools_job.cpu(4)
-    bcftools_job.storage('15G')
+    bcftools_job.storage('20G')
 
     bcftools_job.declare_resource_group(vcf_out={'vcf.gz': '{root}.vcf.gz'})
     bcftools_job.command(
@@ -62,4 +62,4 @@ def main(
 
 
 if __name__ == '__main__':
-    main()  # pylint: disable=no-value-for-parameter
+    main()  # pylint: disable=no-value-for-parameter,unsubscriptable-object

--- a/str/trtools/bcftools_merge_runner.py
+++ b/str/trtools/bcftools_merge_runner.py
@@ -17,16 +17,15 @@ config = get_config()
 
 BCFTOOLS_IMAGE = config['images']['bcftools']
 
+
 # inputs:
 # input directory
 @click.option('--input-dir', help='gs://...')
 # input sample ID
 @click.argument('internal-wgs-ids', nargs=-1)
 @click.command()
-def main(
-    input_dir, internal_wgs_ids: list[str]
-):
-    """ Merge sample VCFs using bcftools merge """
+def main(input_dir, internal_wgs_ids: list[str]):
+    """Merge sample VCFs using bcftools merge"""
 
     # Initializing Batch
     b = get_batch()
@@ -35,10 +34,14 @@ def main(
     batch_vcfs = []
     for id in list(internal_wgs_ids):
         each_vcf = os.path.join(input_dir, f'{id}_eh.reheader.vcf.gz')
-        batch_vcfs.append(b.read_input_group(**{
-            'vcf.gz': each_vcf,
-            'vcf.gz.tbi': f'{each_vcf}.tbi',
-        })['vcf.gz'])
+        batch_vcfs.append(
+            b.read_input_group(
+                **{
+                    'vcf.gz': each_vcf,
+                    'vcf.gz.tbi': f'{each_vcf}.tbi',
+                }
+            )['vcf.gz']
+        )
     num_samples = len(internal_wgs_ids)
 
     bcftools_job = b.new_job(name=f'Bcftools merge job')

--- a/str/trtools/bcftools_merge_runner.py
+++ b/str/trtools/bcftools_merge_runner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=duplicate-code
+# pylint: disable=duplicate-code,unsubscriptable-object
 """
 This script merges ExpansionHunter VCFs together into one VCF using `bcftools merge`
 Required input: --input-dir and external sample IDs
@@ -14,7 +14,7 @@ import os
 import click
 
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import get_batch, output_path, reference_path
+from cpg_utils.hail_batch import get_batch, output_path
 
 config = get_config()
 


### PR DESCRIPTION
`bcftools merge` seems to be an OK (and faster) alternative to `mergeSTR` (which has been stalling with larger catalogs see: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1704685344162619). 