### PR TITLE
Step 3 of debug: Create `merge_str_vcf_combiner.py`

### DIFF
--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+"""
+This script combines sharded output VCFs from mergeSTR into one VCF, and assumes the genotyper used was ExpansionHunter.
+
+analysis-runner --access-level test --dataset tob-wgs --description \
+    'VCF combiner' --output-dir 'hoptan-str/shard_workflow_test/merge_str_vcf_combiner' \
+    merge_str_vcf_combiner.py \
+    --input-dir=gs://cpg-tob-wgs-test/hoptan-str/shard_workflow_test/merge_str \
+"""
+import click
+
+from cpg_utils.config import get_config
+from cpg_utils import to_path
+from cpg_utils.hail_batch import get_batch, output_path
+
+import gzip
+
+config = get_config()
+
+
+def combine_vcf_files(input_dir, gcs_out_path):
+    """Combines sharded mergeSTR output VCFs in input_dir into one combined VCF, writing it to a GCS output path"""
+
+    input_file_paths = to_path(input_dir).glob('*.vcf.gz')
+
+    # make input_files GSPath elements into a string type object
+    input_file_paths = {str(gs_path) for gs_path in input_file_paths}
+
+    #create a dictionary where key is the shard number and value is the path to the shard
+    input_files_dict = {}
+    for file_path in input_file_paths:
+        key = int(file_path.split('eh_shard')[1].split('.')[0])
+        input_files_dict[key] = file_path
+
+    #custom sorted order of shards - PLEASE UPDATE FOR LATER USE
+    sorted_key_order  = [
+    1, 12, 23, 34, 45, 47, 48, 49, 50,
+    2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13,
+    14, 15, 16, 17, 18, 19, 20, 21, 22, 24,
+    25, 26, 27, 28, 29, 30, 31, 32, 33, 35,
+    36, 37, 38, 39, 40, 41, 42, 43, 44, 46
+]
+
+    # Initialize variables to store information
+    fileformat_line = ''
+    info_lines = []
+    alt_lines = set()
+    chrom_line = ''
+    gt_lines = []
+
+    shard_counter = 0
+    # Process each input file
+    for key in sorted_key_order:
+        input_file = to_path(input_files_dict[key])
+        print(f'Parsing {input_file}')
+        shard_counter = shard_counter + 1
+
+        with gzip.open(input_file, 'rt') as f:
+            for line in f:
+                # Collect information from the header lines
+                if line.startswith('##fileformat'):
+                    if key == 1: # first file processed is shard_1
+                        fileformat_line = line
+                elif (
+                    line.startswith('##INFO')
+                    or line.startswith('##FILTER')
+                    or line.startswith('##FORMAT')
+                    or line.startswith('##contig')
+                    or line.startswith('##command')
+                ):
+                    if key == 1:
+                        info_lines.append(line)
+                elif line.startswith('##ALT'):
+                    # Collect ALT lines from all files into a set to remove duplicates
+                    alt_lines.add(line)
+                elif line.startswith('#CHROM'):
+                    if key == 1:
+                        chrom_line = line
+                elif not line.startswith('#'):
+                    # Collect calls after #CHROM
+                    gt_lines.append(line)
+
+    print(f'Parsed {shard_counter} sharded VCFs')
+    # Sort ALT lines alphabetically and convert to a list
+    sorted_alt_lines = sorted(alt_lines)
+
+    # Write the combined information to the output file
+    with to_path(gcs_out_path).open('w') as out_file:
+        # Write fileformat line
+        out_file.write(fileformat_line)
+        # Write INFO, FILTER, and FORMAT lines
+        out_file.writelines(info_lines)
+        # Write ALT lines
+        out_file.writelines(sorted_alt_lines)
+        # Write CHROM line
+        out_file.write(chrom_line)
+        # Write GT or lines containing the calls
+        out_file.writelines(gt_lines)
+
+
+@click.command()
+@click.option(
+    '--input-dir',
+    help='Parent input directory for sharded VCFs',
+)
+def main(input_dir):
+    """
+    Takes an input directory containing vcf shards
+    Aggregates all sharded data into a single output file
+    """
+
+    # Initializing Batch
+    b = get_batch()
+
+
+    combiner_job = b.new_python_job(name=f'VCF Combiner job')
+    out_path = output_path(f'combined_eh.vcf') #enable analysis mode again later for PR
+    combiner_job.call(combine_vcf_files, input_dir, out_path)
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -93,7 +93,6 @@ def combine_vcf_files(input_dir, gcs_out_path):
     chrom_line = ''
     gt_lines = []
 
-    shard_counter = 0
     # Process each input file
     for shard_counter, key in enumerate(sorted_key_order):
         input_file = to_path(input_files_dict[key])

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -124,7 +124,7 @@ def combine_vcf_files(input_dir, gcs_out_path):
                     # Collect calls after #CHROM
                     gt_lines.append(line)
 
-    print(f'Parsed {shard_counter} sharded VCFs')
+    print(f'Parsed {len(sorted_key_order)} sharded VCFs')
     # Sort ALT lines alphabetically and convert to a list
     sorted_alt_lines = sorted(alt_lines)
 

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -153,14 +153,8 @@ def main(input_dir):
     Aggregates all sharded data into a single output file
     """
 
-    # Initializing Batch
-    b = get_batch()
-
-    combiner_job = b.new_python_job(name=f'VCF Combiner job')
     out_path = output_path(f'combined_eh.vcf', 'analysis')
-    combiner_job.call(combine_vcf_files, input_dir, out_path)
-
-    b.run(wait=False)
+    combine_vcf_files(input_dir, out_path)
 
 
 if __name__ == '__main__':

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -27,20 +27,65 @@ def combine_vcf_files(input_dir, gcs_out_path):
     # make input_files GSPath elements into a string type object
     input_file_paths = {str(gs_path) for gs_path in input_file_paths}
 
-    #create a dictionary where key is the shard number and value is the path to the shard
+    # create a dictionary where key is the shard number and value is the path to the shard
     input_files_dict = {}
     for file_path in input_file_paths:
         key = int(file_path.split('eh_shard')[1].split('.')[0])
         input_files_dict[key] = file_path
 
-    #custom sorted order of shards - PLEASE UPDATE FOR LATER USE
-    sorted_key_order  = [
-    1, 12, 23, 34, 45, 47, 48, 49, 50,
-    2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13,
-    14, 15, 16, 17, 18, 19, 20, 21, 22, 24,
-    25, 26, 27, 28, 29, 30, 31, 32, 33, 35,
-    36, 37, 38, 39, 40, 41, 42, 43, 44, 46
-]
+    # custom sorted order of shards - PLEASE UPDATE FOR LATER USE
+    sorted_key_order = [
+        1,
+        12,
+        23,
+        34,
+        45,
+        47,
+        48,
+        49,
+        50,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        33,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42,
+        43,
+        44,
+        46,
+    ]
 
     # Initialize variables to store information
     fileformat_line = ''
@@ -60,7 +105,7 @@ def combine_vcf_files(input_dir, gcs_out_path):
             for line in f:
                 # Collect information from the header lines
                 if line.startswith('##fileformat'):
-                    if key == 1: # first file processed is shard_1
+                    if key == 1:  # first file processed is shard_1
                         fileformat_line = line
                 elif (
                     line.startswith('##INFO')
@@ -113,9 +158,10 @@ def main(input_dir):
     # Initializing Batch
     b = get_batch()
 
-
     combiner_job = b.new_python_job(name=f'VCF Combiner job')
-    out_path = output_path(f'combined_eh.vcf') #enable analysis mode again later for PR
+    out_path = output_path(
+        f'combined_eh.vcf'
+    )  # enable analysis mode again later for PR
     combiner_job.call(combine_vcf_files, input_dir, out_path)
 
     b.run(wait=False)

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -95,7 +95,7 @@ def combine_vcf_files(input_dir, gcs_out_path):
 
     shard_counter = 0
     # Process each input file
-    for key in sorted_key_order:
+    for shard_counter, key in enumerate(sorted_key_order):
         input_file = to_path(input_files_dict[key])
         print(f'Parsing {input_file}')
         shard_counter = shard_counter + 1

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -98,7 +98,6 @@ def combine_vcf_files(input_dir, gcs_out_path):
     for shard_counter, key in enumerate(sorted_key_order):
         input_file = to_path(input_files_dict[key])
         print(f'Parsing {input_file}')
-        shard_counter = shard_counter + 1
 
         with gzip.open(input_file, 'rt') as f:
             for line in f:

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -6,7 +6,7 @@ This script combines sharded output VCFs from mergeSTR into one VCF, and assumes
 analysis-runner --access-level test --dataset tob-wgs --description \
     'VCF combiner' --output-dir 'hoptan-str/shard_workflow_test/merge_str_vcf_combiner' \
     merge_str_vcf_combiner.py \
-    --input-dir=gs://cpg-tob-wgs-test/hoptan-str/shard_workflow_test/merge_str \
+    --input-dir=gs://cpg-tob-wgs-test/hoptan-str/shard_workflow_test/merge_str
 """
 import gzip
 import click
@@ -158,9 +158,7 @@ def main(input_dir):
     b = get_batch()
 
     combiner_job = b.new_python_job(name=f'VCF Combiner job')
-    out_path = output_path(
-        f'combined_eh.vcf'
-    )  # enable analysis mode again later for PR
+    out_path = output_path(f'combined_eh.vcf', 'analysis')
     combiner_job.call(combine_vcf_files, input_dir, out_path)
 
     b.run(wait=False)

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -13,7 +13,7 @@ import click
 
 from cpg_utils.config import get_config
 from cpg_utils import to_path
-from cpg_utils.hail_batch import get_batch, output_path
+from cpg_utils.hail_batch import output_path
 
 config = get_config()
 

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -94,7 +94,7 @@ def combine_vcf_files(input_dir, gcs_out_path):
     gt_lines = []
 
     # Process each input file
-    for shard_counter, key in enumerate(sorted_key_order):
+    for key in sorted_key_order:
         input_file = to_path(input_files_dict[key])
         print(f'Parsing {input_file}')
 

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -8,13 +8,12 @@ analysis-runner --access-level test --dataset tob-wgs --description \
     merge_str_vcf_combiner.py \
     --input-dir=gs://cpg-tob-wgs-test/hoptan-str/shard_workflow_test/merge_str \
 """
+import gzip
 import click
 
 from cpg_utils.config import get_config
 from cpg_utils import to_path
 from cpg_utils.hail_batch import get_batch, output_path
-
-import gzip
 
 config = get_config()
 

--- a/str/trtools/merge_str_prep.py
+++ b/str/trtools/merge_str_prep.py
@@ -84,7 +84,7 @@ def main(
                 bcftools_job.command(
                     f"""
 
-                    bcftools reheader -f {ref.fai} {vcf_input} | bcftools sort --temp-dir $BATCH_TMPDIR/ | bgzip -c >  {bcftools_job.vcf_sorted['reheader.vcf.gz']}
+                    bcftools reheader -f {ref.fai} {vcf_input} | bgzip -c >  {bcftools_job.vcf_sorted['reheader.vcf.gz']}
 
                     tabix -f -p vcf {bcftools_job.vcf_sorted['reheader.vcf.gz']}
 

--- a/str/trtools/merge_str_runner.py
+++ b/str/trtools/merge_str_runner.py
@@ -3,8 +3,10 @@
 This script merges ExpansionHunter vcf.gz files into one combined VCF.
 Please ensure merge_prep.py has been run on the vcf files prior to running mergeSTR.py
 
+Optional ability to add in VCFs from another file directory (but must be sharded in the same way as the input-dir-1)
+
 For example:
-analysis-runner --access-level standard --dataset tob-wgs --description '5M merge TOB100' --output-dir 'str/5M_run_combined_vcfs/merge_str/v4' merge_str_runner.py --input-dir=gs://cpg-tob-wgs-main-analysis/str/5M_run_combined_vcfs/merge_str_prep/v4-2 --dataset=tob-wgs CPG199760 CPG199778
+analysis-runner --access-level standard --dataset tob-wgs --description '5M merge TOB100' --output-dir 'str/5M_run_combined_vcfs/merge_str/v4' merge_str_runner.py --input-dir-1=gs://cpg-tob-wgs-main-analysis/str/5M_run_combined_vcfs/merge_str_prep/v4-2 --num-shards=50 --sample-list-1=gs://
 
 Required packages: sample-metadata, hail, click, os
 pip install sample-metadata hail click
@@ -13,6 +15,7 @@ import os
 
 import click
 
+from cpg_utils import to_path
 from cpg_utils.config import get_config
 from cpg_utils.hail_batch import get_batch, output_path
 
@@ -23,60 +26,98 @@ TRTOOLS_IMAGE = config['images']['trtools']
 
 
 # inputs:
-# input directory
-@click.option('--input-dir', help='gs://...')
-# input sample ID
-@click.argument('internal-wgs-ids', nargs=-1)
+
+
+# input directory 1
+@click.option('--input-dir-1', help='gs://...')
+# input directory 2
+@click.option('--input-dir-2', help='gs://...', default=None)
+# sample list 1 (CPG sample IDs separated by \n)
+@click.option('--sample-list-1', help='gs://...')
+# sample list 2 (CPG sample IDs separated by \n)
+@click.option('--sample-list-2', help='gs://...', default=None)
+# input num shards
 @click.option(
-    '--job-storage', help='Storage of the Hail batch job eg 30G', default='50G'
+    '--num-shards',
+    type=int,
+    default=1,
+    help=('Number of shards per sample to expect (if unsharded, choose 1)'),
+)
+@click.option(
+    '--job-storage', help='Storage of the Hail batch job eg 30G', default='20G'
 )
 @click.command()
 def main(
-    job_storage, input_dir, internal_wgs_ids: list[str]
+    job_storage, input_dir_1, input_dir_2, sample_list_1, sample_list_2, num_shards
 ):  # pylint: disable=missing-function-docstring
     # Initializing Batch
     b = get_batch()
-
-    # Initialise TRTools job to run mergeSTR
-    trtools_job = b.new_job(name='mergeSTR')
-    trtools_job.image(TRTOOLS_IMAGE)
-    trtools_job.cpu(16)
-    trtools_job.storage(job_storage)
-    trtools_job.declare_resource_group(
-        vcf_output={
-            'vcf': '{root}.vcf',
-            'vcf.gz': '{root}.vcf.gz',
-            'vcf.gz.tbi': '{root}.vcf.gz.tbi',
-        }
-    )
-
-    # read in input file paths
-    batch_vcfs = []
-    for id in list(internal_wgs_ids):
-        each_vcf = os.path.join(input_dir, f'{id}_eh.reheader.vcf.gz')
-        batch_vcfs.append(
-            b.read_input_group(
-                **{
-                    'vcf.gz': each_vcf,
-                    'vcf.gz.tbi': f'{each_vcf}.tbi',
-                }
-            )['vcf.gz']
+    for shard_index in enumerate(num_shards, 1):
+        # Initialise TRTools job to run mergeSTR
+        trtools_job = b.new_job(name=f'mergeSTR shard {shard_index}')
+        trtools_job.image(TRTOOLS_IMAGE)
+        trtools_job.cpu(8)
+        trtools_job.storage(job_storage)
+        trtools_job.declare_resource_group(
+            vcf_output={
+                'vcf': '{root}.vcf',
+                'vcf.gz': '{root}.vcf.gz',
+                'vcf.gz.tbi': '{root}.vcf.gz.tbi',
+            }
         )
-    num_samples = len(internal_wgs_ids)
 
-    trtools_job.command(
-        f"""
-    mergeSTR --vcfs {",".join(batch_vcfs)} --out {trtools_job.vcf_output} --vcftype eh
-    bgzip -c {trtools_job.vcf_output}.vcf > {trtools_job.vcf_output['vcf.gz']}
-    tabix -f -p vcf {trtools_job.vcf_output['vcf.gz']}  > {trtools_job.vcf_output['vcf.gz.tbi']}
-    """
-    )
+        # read in input file paths
+        batch_vcfs = []
+        num_samples = 0
+        with to_path(sample_list_1).open() as f_1:
+            ids_1 = [line.strip() for line in f_1]
+            for id in ids_1:
+                each_vcf = os.path.join(
+                    input_dir_1, f'{id}_eh_shard{shard_index}.reheader.vcf.gz'
+                )
+                batch_vcfs.append(
+                    b.read_input_group(
+                        **{
+                            'vcf.gz': each_vcf,
+                            'vcf.gz.tbi': f'{each_vcf}.tbi',
+                        }
+                    )['vcf.gz']
+                )
+            num_samples = num_samples + len(ids_1)
 
-    output_path_name = output_path(f'mergeSTR_{num_samples}_samples_eh', 'analysis')
-    b.write_output(trtools_job.vcf_output['vcf.gz'], f'{output_path_name}.vcf.gz')
-    b.write_output(
-        trtools_job.vcf_output['vcf.gz.tbi'], f'{output_path_name}.vcf.gz.tbi'
-    )
+        # if second file directory is specified, read in input file paths:
+        if input_dir_2 is not None:
+            with to_path(sample_list_2).open() as f_2:
+                ids_2 = [line.strip() for line in f_2]
+                for id in ids_2:
+                    each_vcf = os.path.join(
+                        input_dir_2, f'{id}_eh_shard{shard_index}.reheader.vcf.gz'
+                    )
+                    batch_vcfs.append(
+                        b.read_input_group(
+                            **{
+                                'vcf.gz': each_vcf,
+                                'vcf.gz.tbi': f'{each_vcf}.tbi',
+                            }
+                        )['vcf.gz']
+                    )
+                num_samples = num_samples + len(ids_2)
+
+        trtools_job.command(
+            f"""
+        mergeSTR --vcfs {",".join(batch_vcfs)} --out {trtools_job.vcf_output} --vcftype eh
+        bgzip -c {trtools_job.vcf_output}.vcf > {trtools_job.vcf_output['vcf.gz']}
+        tabix -f -p vcf {trtools_job.vcf_output['vcf.gz']}  > {trtools_job.vcf_output['vcf.gz.tbi']}
+        """
+        )
+
+        output_path_name = output_path(
+            f'mergeSTR_{num_samples}_samples_eh_shard{shard_index}', 'analysis'
+        )
+        b.write_output(trtools_job.vcf_output['vcf.gz'], f'{output_path_name}.vcf.gz')
+        b.write_output(
+            trtools_job.vcf_output['vcf.gz.tbi'], f'{output_path_name}.vcf.gz.tbi'
+        )
 
     b.run(wait=False)
 


### PR DESCRIPTION
This is a new script that concatenates sharded mergeSTR output VCFs together into one combined VCF. 

Please note there is a custom sorted order of shards because shard_label of the VCFs unintentionally followed a different order to the way the catalog was sharded; so I am enforcing this order to ensure the VCF shards are added in the right chromosome/position order. 

Details of the shard order error: 
Catalog shards were read in as shard_1, shard_10, shard_11...shard_19, shard_2, shard_20..and so on (alphabetical order) 
This means that catalog shard_10 maps to VCF shard_2 because when EH was running, the shard_counter just increased by 1 each time a new catalog shard was read in. I will fix this after the BioHEART n=100 run (just so that this custom sort order applies to all n=200 samples). 

