### PR TITLE
Create polymorphic_site_extractor.py

### DIFF
--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -39,14 +39,14 @@ def polymorphic_site_extractor(file_path):
     mt = hl.sample_qc(mt)
     mt = hl.variant_qc(mt)
 
-    # remove chrY and chrM
+    # remove chrY and chrM, monomorphic REF sites, monomorphic ALT at bialellic loci
     filtered_mt = mt.filter_rows(
         (hl.str(mt.locus.contig).startswith('chrY')) |
-        (hl.str(filtered_mt.locus.contig).startswith('chrM')) |
-        (hl.len(filtered_mt.alleles) == 1) |
+        (hl.str(mt.locus.contig).startswith('chrM')) |
+        (hl.len(mt.alleles) == 1) |
         (
-            (hl.len(filtered_mt.variant_qc.AC) == 2)
-            & (filtered_mt.variant_qc.AC[0] == 0)
+            (hl.len(mt.variant_qc.AC) == 2)
+            & (mt.variant_qc.AC[0] == 0)
         ), keep=False
     )
 

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -93,7 +93,7 @@ def catalog_filter(rep_id_list, catalog_path, gcs_output_path):
 def catalog_sharder(filtered_data, chunk_size, folder_name):
     """Shards a filtered catalog JSON file into chunks of size chunk_size"""
     if not isinstance(filtered_data, list):
-        print("Invalid JSON format. The file should contain a list.")
+        print('Invalid JSON format. The file should contain a list.')
         return
 
     total_entries = len(filtered_data)
@@ -113,10 +113,10 @@ def catalog_sharder(filtered_data, chunk_size, folder_name):
         with to_path(output_file_path).open('w') as output_file:
             json.dump(chunk_data, output_file, indent=2)
 
-        print(f"Chunk {i + 1} created: {output_file_path}")
+        print(f'Chunk {i + 1} created: {output_file_path}')
 
-    print(f"Total entries: {total_entries}")
-    print(f"{num_chunks} chunks written successfully!")
+    print(f'Total entries: {total_entries}')
+    print(f'{num_chunks} chunks written successfully!')
 
 
 @click.option(

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -111,28 +111,15 @@ def catalog_sharder(filtered_data, chunk_size, folder_name):
     print(f'{num_chunks} chunks written successfully!')
 
 
-@click.option(
-    '--vcf-path',
-    help='GCS file path VCF',
-    type=str,
-)
-@click.option(
-    '--catalog-path',
-    help='GCS file path to catalog JSON to be filtered',
-    type=str,
-)
+@click.option('--vcf-path', help='GCS file path VCF')
+@click.option('--catalog-path', help='GCS file path to catalog JSON to be filtered')
 @click.option(
     '--chunk-size',
     help='Number of entries per shard',
     type=int,
     default=100000,
 )
-@click.option(
-    '--folder-name',
-    help='Name of output folder to store shards',
-    type=str,
-    default='sharded_polymorphic_catalog',
-)
+@click.option('--folder-name', help='Name of output folder to store shards', default='sharded_polymorphic_catalog')
 @click.command()
 def main(vcf_path, catalog_path, chunk_size, folder_name):
     # Extract polymorphic sites from VCF

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -13,10 +13,10 @@ Note this script also removes chrY and chrM sites.
     polymorphic_site_extractor.py --file-path=gs://cpg-tob-wgs-test/hoptan-str/shard_workflow_test/merge_str_vcf_combiner/combined_eh.vcf
 
 """
-
+import csv
 import hail as hl
 import click
-import csv
+
 
 from cpg_utils import to_path
 from cpg_utils.hail_batch import output_path, init_batch
@@ -31,10 +31,10 @@ def polymorphic_site_extractor(file_path, gcs_path):
     mt = hl.sample_qc(mt)
     mt = hl.variant_qc(mt)
 
-    ## remove chrY and chrM
-    filtered_mt = mt.filter_rows(~hl.str(mt.locus.contig).startswith("chrY"))
+    # remove chrY and chrM
+    filtered_mt = mt.filter_rows(~hl.str(mt.locus.contig).startswith('chrY'))
     filtered_mt = filtered_mt.filter_rows(
-        ~hl.str(filtered_mt.locus.contig).startswith("chrM")
+        ~hl.str(filtered_mt.locus.contig).startswith('chrM')
     )
 
     # remove loci that are monomorphic for the REF allele

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -11,7 +11,7 @@ Note this script also removes chrY and chrM sites.
     --output-dir "hoptan-str/catalog-design/" \
     --memory=32G --storage=20G \
     polymorphic_site_extractor.py --vcf-path=gs://cpg-tob-wgs-test/hoptan-str/shard_workflow_test/merge_str_vcf_combiner/combined_eh.vcf \
-    --catalog-path=gs://cpg-tob-wgs-test/hoptan-str/5M_run/combined_catalog.trf_at_least_9bp.with_adjacent_loci.annotated_and_filtered.json
+    --catalog-path=gs://cpg-tob-wgs-test/hoptan-str/5M_run/5M_sharded_100k/chunk_1.json
 
 """
 import json
@@ -24,7 +24,7 @@ from cpg_utils.hail_batch import output_path, init_batch
 
 
 def polymorphic_site_extractor(file_path):
-    """ Extracts polymorphic sites from a VCF file and returns a list of REPIDs (similar to rsids) representing those sites """
+    """Extracts polymorphic sites from a VCF file and returns a list of REPIDs (similar to rsids) representing those sites"""
     init_batch()
     # read in VCF into mt format
     mt = hl.import_vcf(file_path)
@@ -56,7 +56,7 @@ def polymorphic_site_extractor(file_path):
 
 
 def catalog_filter(rep_id_list, catalog_path, gcs_output_path):
-    """ Retains loci in a JSON file that intersect with a list of REPIDs (rsids) and writes the filtered catalog to a new JSON file"""
+    """Retains loci in a JSON file that intersect with a list of REPIDs (rsids) and writes the filtered catalog to a new JSON file"""
     with to_path(catalog_path).open('r') as json_file:
         # Load the JSON content
         catalog = json.load(json_file)

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -41,9 +41,9 @@ def polymorphic_site_extractor(file_path):
 
     # remove chrY and chrM
     filtered_mt = mt.filter_rows(
-        (hl.str(mt.locus.contig).startswith('chrY'))) |
-        (hl.str(filtered_mt.locus.contig).startswith('chrM')) | 
-        (hl.len(filtered_mt.alleles) == 1)) |
+        (hl.str(mt.locus.contig).startswith('chrY')) |
+        (hl.str(filtered_mt.locus.contig).startswith('chrM')) |
+        (hl.len(filtered_mt.alleles) == 1) |
         (
             (hl.len(filtered_mt.variant_qc.AC) == 2)
             & (filtered_mt.variant_qc.AC[0] == 0)

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -15,7 +15,6 @@ Note this script also removes chrY and chrM sites.
 
 """
 import json
-import csv
 import hail as hl
 import click
 

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -68,7 +68,6 @@ def catalog_filter(rep_id_list, catalog_path, gcs_output_path):
         # Load the JSON content
         catalog = json.load(json_file)
 
-    # Filter the JSON entries based on the VariantID
     filtered_data = []
 
     # Make the rep_id_list into a set
@@ -80,11 +79,11 @@ def catalog_filter(rep_id_list, catalog_path, gcs_output_path):
             set(entry['VariantId']) if 'VariantId' in entry else {entry['LocusId']}
         )
 
-        # Check if there is an intersection with polymorphic_rep_id_set
+        # Append to filtered_data if the entry Variant Id intersects with polymorphic_rep_id_set
         if entry_variant_ids & polymorphic_rep_id_set:
             filtered_data.append(entry)
 
-    # Write the combined information to the output file
+    # Write to output
     with to_path(gcs_output_path).open('w') as out_file:
         json.dump(filtered_data, out_file, indent=2)
     return filtered_data
@@ -126,7 +125,7 @@ def catalog_sharder(filtered_data, chunk_size, folder_name):
 )
 @click.option(
     '--catalog-path',
-    help='GCS file path to catalog JSON',
+    help='GCS file path to catalog JSON to be filtered',
     type=str,
 )
 @click.option(

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -25,8 +25,7 @@ from cpg_utils.hail_batch import output_path, init_batch
 def polymorphic_site_extractor(file_path, gcs_path):
     init_batch()
     # read in VCF into mt format
-    hl.import_vcf(file_path).write('5M_n200.mt', overwrite=True)
-    mt = hl.read_matrix_table('5M_n200.mt')
+    mt = hl.import_vcf(file_path)
 
     mt = hl.sample_qc(mt)
     mt = hl.variant_qc(mt)

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -40,20 +40,14 @@ def polymorphic_site_extractor(file_path):
     mt = hl.variant_qc(mt)
 
     # remove chrY and chrM
-    filtered_mt = mt.filter_rows(~hl.str(mt.locus.contig).startswith('chrY'))
-    filtered_mt = filtered_mt.filter_rows(
-        ~hl.str(filtered_mt.locus.contig).startswith('chrM')
-    )
-
-    # remove loci that are monomorphic for the REF allele
-    filtered_mt = filtered_mt.filter_rows(hl.len(filtered_mt.alleles) > 1)
-
-    # at a biallelic locus, remove loci that are monomorphic for 1 ALT allele
-    filtered_mt = filtered_mt.filter_rows(
-        ~(
+    filtered_mt = mt.filter_rows(
+        (hl.str(mt.locus.contig).startswith('chrY'))) |
+        (hl.str(filtered_mt.locus.contig).startswith('chrM')) | 
+        (hl.len(filtered_mt.alleles) == 1)) |
+        (
             (hl.len(filtered_mt.variant_qc.AC) == 2)
             & (filtered_mt.variant_qc.AC[0] == 0)
-        )
+        ), keep=False
     )
 
     # collect the REPIDs into one list

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -120,11 +120,11 @@ def catalog_sharder(filtered_data, chunk_size, folder_name):
 @click.command()
 def main(vcf_path, catalog_path, chunk_size, folder_name):
     # Extract polymorphic sites from VCF
-    rep_id_list = polymorphic_site_extractor(vcf_path)
+    rep_id_set = polymorphic_site_extractor(vcf_path)
 
     # Filter catalog JSON file for polymorphic sites
     catalog_output_path = output_path(f'filtered_polymorphic_catalog.json', 'analysis')
-    filtered_catalog = catalog_filter(rep_id_list, catalog_path, catalog_output_path)
+    filtered_catalog = catalog_filter(rep_id_set, catalog_path, catalog_output_path)
 
     # Shard the filtered catalog
     catalog_sharder(filtered_catalog, chunk_size, folder_name)

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-function-docstring,no-member
+"""
+This Hail Query script outputs a CSV file containing REPIDs (RepeatIDs) of sites that are polymorphic in a given VCF.
+Polymorphic sites are those that have at least two distinct alleles occuring in the VCF.
+Note this script also removes chrY and chrM sites.
+
+
+ analysis-runner --dataset "bioheart" \
+    --description "polymorphic-site-extractor" \
+    --access-level "test" \
+    --output-dir "hoptan-str/catalog-design/" \
+    polymorphic_site_extractor.py --file-path=gs://cpg-tob-wgs-test/hoptan-str/shard_workflow_test/merge_str_vcf_combiner/combined_eh.vcf
+
+"""
+
+import hail as hl
+import click
+import csv
+
+from cpg_utils import to_path
+from cpg_utils.hail_batch import output_path, init_batch
+
+
+def polymorphic_site_extractor(file_path, gcs_path):
+    init_batch()
+    # read in VCF into mt format
+    hl.import_vcf(file_path).write('5M_n200.mt', overwrite=True)
+    mt = hl.read_matrix_table('5M_n200.mt')
+
+    mt = hl.sample_qc(mt)
+    mt = hl.variant_qc(mt)
+
+    ## remove chrY and chrM
+    filtered_mt = mt.filter_rows(~hl.str(mt.locus.contig).startswith("chrY"))
+    filtered_mt = filtered_mt.filter_rows(
+        ~hl.str(filtered_mt.locus.contig).startswith("chrM")
+    )
+
+    # remove loci that are monomorphic for the REF allele
+    filtered_mt = filtered_mt.filter_rows(hl.len(filtered_mt.alleles) > 1)
+
+    # at a biallelic locus, remove loci that are monomorphic for 1 ALT allele
+    filtered_mt = filtered_mt.filter_rows(
+        ~(
+            (hl.len(filtered_mt.variant_qc.AC) == 2)
+            & (filtered_mt.variant_qc.AC[0] == 0)
+        )
+    )
+
+    # collect the REPIDs into one list
+    rep_id_list = filtered_mt.info.REPID.collect()
+
+    # Write the combined information to the output file
+    with to_path(gcs_path).open('w') as out_file:
+        writer = csv.writer(out_file)
+        writer.writerow(rep_id_list)
+
+
+@click.option(
+    '--file-path',
+    help='GCS file path VCF',
+    type=str,
+)
+@click.command()
+def main(file_path):
+    gcs_output_path = output_path(f'polymorphic_sites_rep_id.csv', 'analysis')
+    polymorphic_site_extractor(file_path, gcs_output_path)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -41,13 +41,11 @@ def polymorphic_site_extractor(file_path):
 
     # remove chrY and chrM, monomorphic REF sites, monomorphic ALT at bialellic loci
     filtered_mt = mt.filter_rows(
-        (hl.str(mt.locus.contig).startswith('chrY')) |
-        (hl.str(mt.locus.contig).startswith('chrM')) |
-        (hl.len(mt.alleles) == 1) |
-        (
-            (hl.len(mt.variant_qc.AC) == 2)
-            & (mt.variant_qc.AC[0] == 0)
-        ), keep=False
+        (hl.str(mt.locus.contig).startswith('chrY'))
+        | (hl.str(mt.locus.contig).startswith('chrM'))
+        | (hl.len(mt.alleles) == 1)
+        | ((hl.len(mt.variant_qc.AC) == 2) & (mt.variant_qc.AC[0] == 0)),
+        keep=False,
     )
 
     # collect the REPIDs into one list
@@ -56,7 +54,9 @@ def polymorphic_site_extractor(file_path):
     return rep_id_list
 
 
-def catalog_filter(polymorphic_rep_id_set: set[str], catalog_path: str, gcs_output_path: str):
+def catalog_filter(
+    polymorphic_rep_id_set: set[str], catalog_path: str, gcs_output_path: str
+):
     """Retains loci in a JSON file that intersect with a list of REPIDs (STR equiv. of rsids) and writes the filtered catalog to a new JSON file"""
     with to_path(catalog_path).open('r') as json_file:
         # Load the JSON content
@@ -116,7 +116,11 @@ def catalog_sharder(filtered_data, chunk_size, folder_name):
     type=int,
     default=100000,
 )
-@click.option('--folder-name', help='Name of output folder to store shards', default='sharded_polymorphic_catalog')
+@click.option(
+    '--folder-name',
+    help='Name of output folder to store shards',
+    default='sharded_polymorphic_catalog',
+)
 @click.command()
 def main(vcf_path, catalog_path, chunk_size, folder_name):
     # Extract polymorphic sites from VCF

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -86,8 +86,7 @@ def catalog_filter(rep_id_list, catalog_path, gcs_output_path):
 def catalog_sharder(filtered_data, chunk_size, folder_name):
     """Shards a filtered catalog JSON file into chunks of size chunk_size"""
     if not isinstance(filtered_data, list):
-        print('Invalid JSON format. The file should contain a list.')
-        return
+        raise ValueError('Invalid JSON format. The file should contain a list.')
 
     total_entries = len(filtered_data)
     num_chunks = total_entries // chunk_size

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -24,7 +24,9 @@ from cpg_utils.hail_batch import output_path, init_batch
 
 
 def polymorphic_site_extractor(file_path):
-    """Extracts polymorphic sites from a VCF file and returns a list of REPIDs (similar to rsids) representing those sites"""
+    """Extracts polymorphic sites from a VCF file and returns a list of REPIDs (similar to rsids) representing those sites
+    The output has been benchmarked with Gymrek's statSTR and agrees with the number of polymorphic sites found
+    """
     init_batch()
     # read in VCF into mt format
     mt = hl.import_vcf(file_path)
@@ -56,7 +58,7 @@ def polymorphic_site_extractor(file_path):
 
 
 def catalog_filter(rep_id_list, catalog_path, gcs_output_path):
-    """Retains loci in a JSON file that intersect with a list of REPIDs (rsids) and writes the filtered catalog to a new JSON file"""
+    """Retains loci in a JSON file that intersect with a list of REPIDs (STR equiv. of rsids) and writes the filtered catalog to a new JSON file"""
     with to_path(catalog_path).open('r') as json_file:
         # Load the JSON content
         catalog = json.load(json_file)

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -56,16 +56,13 @@ def polymorphic_site_extractor(file_path):
     return rep_id_list
 
 
-def catalog_filter(rep_id_list, catalog_path, gcs_output_path):
+def catalog_filter(polymorphic_rep_id_set: set[str], catalog_path: str, gcs_output_path: str):
     """Retains loci in a JSON file that intersect with a list of REPIDs (STR equiv. of rsids) and writes the filtered catalog to a new JSON file"""
     with to_path(catalog_path).open('r') as json_file:
         # Load the JSON content
         catalog = json.load(json_file)
 
     filtered_data = []
-
-    # Make the rep_id_list into a set
-    polymorphic_rep_id_set = set(rep_id_list)
 
     for entry in catalog:
         # Check if 'VariantId' exists, use 'LocusId' otherwise

--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -51,7 +51,7 @@ def polymorphic_site_extractor(file_path):
     )
 
     # collect the REPIDs into one list
-    rep_id_list = filtered_mt.info.REPID.collect()
+    rep_id_list = filtered_mt.info.REPID.collect_as_set()
 
     return rep_id_list
 


### PR DESCRIPTION
This script performs three functions: 
- extracts polymorphic sites from a VCF (containing GTs from multiple samples). 
- filters a variant catalog JSON file to only include those polymorphic sites, outputting a filtered catalog JSON file to GCS
- shards this filtered catalog into chunks, outputting each sharded JSON file to GCS (ready for EH genotyping). 

Sharded filtered polymorphic catalog will then be used for genotyping in the rest of the cohort

Note to reviewer - any mention of REPID is the STR equivalent of rsid ie an id that is unique to a particular variant. 

Test batch run: https://batch.hail.populationgenomics.org.au/batches/432365/jobs/1

First method (extracting polymorphic sites from VCF) has been benchmarked with Gymrek's statSTR package and results agree so I'm comfortable with the filtering. 

A closer look at the second method would be good, in case I've missed any logic errors. 