### PR TITLE
Sorts the sharded catalog files by shard number numerically, not alphabetically! 

### DIFF
--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -14,60 +14,6 @@ import click
 from cpg_utils import to_path
 from cpg_utils.hail_batch import output_path
 
-# custom sorted order of shards - PLEASE UPDATE FOR LATER USE
-SORTED_KEY_ORDER = [
-    1,
-    12,
-    23,
-    34,
-    45,
-    47,
-    48,
-    49,
-    50,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8,
-    9,
-    10,
-    11,
-    13,
-    14,
-    15,
-    16,
-    17,
-    18,
-    19,
-    20,
-    21,
-    22,
-    24,
-    25,
-    26,
-    27,
-    28,
-    29,
-    30,
-    31,
-    32,
-    33,
-    35,
-    36,
-    37,
-    38,
-    39,
-    40,
-    41,
-    42,
-    43,
-    44,
-    46,
-]
-
 
 @click.command()
 @click.option('--input-dir', help='Parent input directory for sharded VCFs')
@@ -100,7 +46,7 @@ def main(input_dir, output):
     temporary_gt_file = 'temporary_gt_file.txt'
     with open(temporary_gt_file, 'w', encoding='utf-8') as handle:
         # Process each input file
-        for key in SORTED_KEY_ORDER:
+        for key in sorted(input_files_dict.keys()):
             input_file = to_path(input_files_dict[key])
             print(f'Parsing {input_file}')
 
@@ -129,7 +75,7 @@ def main(input_dir, output):
                         # Collect calls after #CHROM in a temp file
                         handle.write(line)
 
-    print(f'Parsed {len(SORTED_KEY_ORDER)} sharded VCFs')
+    print(f'Parsed {len(list(input_files_dict.keys()))} sharded VCFs')
 
     # Write the combined information to the output file
     with to_path(output_path(output, 'analysis')).open('w') as out_file:

--- a/str/runners/str_iterative_eh_runner.py
+++ b/str/runners/str_iterative_eh_runner.py
@@ -7,13 +7,13 @@ Required input: --variant-catalog (file path to variant catalog, can be sharded 
 EH will run on every sample listed inthe sample mapping file.
 
 For example:
-analysis-runner --access-level full --dataset tob-wgs --description 'n100 5M run' --output-dir 'str/5M_run' str_iterative_eh_runner.py --variant-catalog=gs://cpg-tob-wgs-test/hoptan-str/5M_run/5M_sharded_100k/ --dataset=tob-wgs --sample-id-file=gs://cpg-tob-wgs-test/hoptan-str/5M_run/sampled_tob_n100_subset.csv
+analysis-runner --access-level test --dataset tob-wgs --description 'n100 5M run' --output-dir 'str/5M_run' str_iterative_eh_runner.py --variant-catalog=gs://cpg-tob-wgs-test/hoptan-str/5M_run/5M_sharded_100k/ --dataset=tob-wgs-test --sample-id-file=gs://cpg-tob-wgs-test/hoptan-str/5M_run/n1_test_file.csv
 
 Required packages: str_iterative_eh_runner_requirements.txt
 
 """
-import click
 import re
+import click
 
 from metamist.graphql import gql, query
 


### PR DESCRIPTION
Previously the shards were sorted alphabetically eg chunk_1, chunk_10, chunk_2 and so on. This change sorts the chunk files numerically. This means that for example job 42 will align with genotyping sites on chunk_42, which is more intuitive. 