### PR TITLE
revert back to collect()

### DIFF
--- a/str/catalog_design/polymorphic_site_extractor.py
+++ b/str/catalog_design/polymorphic_site_extractor.py
@@ -49,9 +49,10 @@ def polymorphic_site_extractor(file_path):
     )
 
     # collect the REPIDs into one list
-    rep_id_list = filtered_mt.info.REPID.collect_as_set()
+    rep_id_list = filtered_mt.info.REPID.collect()
+    rep_id_set = set(rep_id_list)
 
-    return rep_id_list
+    return rep_id_set
 
 
 def catalog_filter(


### PR DESCRIPTION
`collect_as_set()` is a Hail aggregator function, so requires some agg. .... to work. 

https://batch.hail.populationgenomics.org.au/batches/432438/jobs/1
`AttributeError: 'StringExpression' object has no attribute 'collect_as_set'
`