### PR TITLE
Update combiner script 

### DIFF
--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -39,7 +39,7 @@ def main(input_dir, output):
         for file_path in input_file_paths
     }
 
-    with gzip.open(to_path(output_path(output, 'analysis'), 'wt')) as handle:
+    with gzip.open(to_path(output_path(output, 'analysis')), 'wt') as handle:
         # Process each input file
         for key in sorted(input_files_dict.keys()):
             input_file = to_path(input_files_dict[key])

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -15,10 +15,9 @@ import click
 from cpg_utils import to_path
 from cpg_utils.hail_batch import output_path
 
-
 @click.command()
 @click.option('--input-dir', help='Parent input directory for sharded VCFs')
-@click.option('--output', help='Name of output VCF', default='combined_eh.vcf')
+@click.option('--output', help='Name of output VCF', default='combined_eh.vcf.gz')
 def main(input_dir, output):
     """
     Combines sharded mergeSTR output VCFs in input_dir into one combined VCF,
@@ -44,7 +43,7 @@ def main(input_dir, output):
     chrom_line = ''
 
     temporary_gt_file = 'temporary_gt_file.txt'
-    with open(temporary_gt_file, 'w', encoding='utf-8') as handle:
+    with gzip.open(temporary_gt_file, 'wt', encoding='utf-8') as handle:
         # Process each input file
         for key in sorted(input_files_dict.keys()):
             input_file = to_path(input_files_dict[key])
@@ -78,7 +77,7 @@ def main(input_dir, output):
 
     # Write the combined information to the output file
     temporary_out_file = 'temporary_out_file.txt'
-    with open(temporary_out_file, 'w', encoding='utf-8') as out_file:
+    with gzip.open(temporary_out_file, 'wt', encoding='utf-8') as out_file:
         # Write fileformat line
         out_file.write(fileformat_line)
         # Write INFO, FILTER, and FORMAT lines
@@ -87,7 +86,7 @@ def main(input_dir, output):
         out_file.write(chrom_line)
 
         # read-write all GT lines from temporary file
-        with open(temporary_gt_file, 'r', encoding='utf-8') as handle:
+        with gzip.open(temporary_gt_file, 'r', encoding='utf-8') as handle:
             for line in handle:
                 out_file.write(line)
 

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -8,14 +8,13 @@ analysis-runner --access-level standard --dataset tob-wgs --description  \
     merge_str_vcf_combiner.py \
     --input-dir=gs://cpg-tob-wgs-main-analysis/str/5M_run_combined_vcfs/merge_str/v5
 """
-import gzip
 import click
+import gzip
+
 
 
 from cpg_utils import to_path
 from cpg_utils.hail_batch import output_path
-import gzip
-
 
 @click.command()
 @click.option('--input-dir', help='Parent input directory for sharded VCFs')

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -91,7 +91,7 @@ def main(input_dir, output):
             for line in handle:
                 out_file.write(line)
 
-    to_path(output_path(output, 'analysis')).upload_from(out_file)
+    to_path(output_path(output, 'analysis')).upload_from(temporary_out_file)
 
 
 if __name__ == '__main__':

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -15,6 +15,7 @@ import click
 from cpg_utils import to_path
 from cpg_utils.hail_batch import output_path
 
+
 @click.command()
 @click.option('--input-dir', help='Parent input directory for sharded VCFs')
 @click.option('--output', help='Name of output VCF', default='combined_eh.vcf.gz')

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -14,11 +14,12 @@ import click
 
 from cpg_utils import to_path
 from cpg_utils.hail_batch import output_path
+import gzip
 
 
 @click.command()
 @click.option('--input-dir', help='Parent input directory for sharded VCFs')
-@click.option('--output', help='Name of output VCF', default='combined_eh.vcf')
+@click.option('--output', help='Name of output VCF', default='combined_eh.vcf.gz')
 def main(input_dir, output):
     """
     Combines sharded mergeSTR output VCFs in input_dir into one combined VCF,
@@ -38,7 +39,7 @@ def main(input_dir, output):
         for file_path in input_file_paths
     }
 
-    with to_path(output_path(output, 'analysis')).open('w') as handle:
+    with gzip.open(to_path(output_path(output, 'analysis'), 'wt')) as handle:
         # Process each input file
         for key in sorted(input_files_dict.keys()):
             input_file = to_path(input_files_dict[key])

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -19,7 +19,7 @@ import gzip
 
 @click.command()
 @click.option('--input-dir', help='Parent input directory for sharded VCFs')
-@click.option('--output', help='Name of output VCF', default='combined_eh.vcf.gz')
+@click.option('--output', help='Name of output VCF', default='combined_eh.vcf')
 def main(input_dir, output):
     """
     Combines sharded mergeSTR output VCFs in input_dir into one combined VCF,

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -73,11 +73,13 @@ def main(input_dir, output):
                     elif not line.startswith('#'):
                         # Collect calls after #CHROM in a temp file
                         handle.write(line)
+            input_file.clear_cache()
 
     print(f'Parsed {len(list(input_files_dict.keys()))} sharded VCFs')
 
     # Write the combined information to the output file
-    with to_path(output_path(output, 'analysis')).open('w') as out_file:
+    temporary_out_file = 'temporary_out_file.txt'
+    with open(temporary_out_file, 'w', encoding='utf-8') as out_file:
         # Write fileformat line
         out_file.write(fileformat_line)
         # Write INFO, FILTER, and FORMAT lines
@@ -89,6 +91,8 @@ def main(input_dir, output):
         with open(temporary_gt_file, 'r', encoding='utf-8') as handle:
             for line in handle:
                 out_file.write(line)
+
+    to_path(output_path(output, 'analysis')).upload_from(out_file)
 
 
 if __name__ == '__main__':

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -8,13 +8,13 @@ analysis-runner --access-level standard --dataset tob-wgs --description  \
     merge_str_vcf_combiner.py \
     --input-dir=gs://cpg-tob-wgs-main-analysis/str/5M_run_combined_vcfs/merge_str/v5
 """
-import click
 import gzip
-
+import click
 
 
 from cpg_utils import to_path
 from cpg_utils.hail_batch import output_path
+
 
 @click.command()
 @click.option('--input-dir', help='Parent input directory for sharded VCFs')

--- a/str/helper/merge_str_vcf_combiner.py
+++ b/str/helper/merge_str_vcf_combiner.py
@@ -86,7 +86,7 @@ def main(input_dir, output):
         out_file.write(chrom_line)
 
         # read-write all GT lines from temporary file
-        with gzip.open(temporary_gt_file, 'r', encoding='utf-8') as handle:
+        with gzip.open(temporary_gt_file, 'rt') as handle:
             for line in handle:
                 out_file.write(line)
 


### PR DESCRIPTION
Problem - with 890 samples, storage requirements of current script is not feasible (>80G allocated and still failing). 

Changes: 
- Added caching to input files after parsing through each of them one by one - reduces storage
- Used `upload_from()` to upload the temporary output file to GCP instead of writing directly to GCS - reduces memory
- Bgzip all temporary and final files - reduces storage and memory by 4x. 

(https://centrepopgen.slack.com/archives/C030X7WGFCL/p1706846188154669?thread_ts=1705629950.573249&cid=C030X7WGFCL)