### PR TITLE
Create a VCF pruner - filter a VCF for VARIDs that intersect with a provided catalog. 

### DIFF
--- a/str/helper/mt_extractor.py
+++ b/str/helper/mt_extractor.py
@@ -23,7 +23,7 @@ from cpg_utils.hail_batch import output_path, init_batch
 def main(file_path):
     """writes a BGZIP VCF as a Hail Matrix Table to a GCS bucket"""
 
-    init_batch()
+    init_batch(worker_memory='highmem')
     gcs_path = output_path('str.mt')
     hl.import_vcf(file_path, force_bgz=True).write(gcs_path, overwrite=True)
 

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -107,3 +107,6 @@ def main(json_file_dir, vcf_file_dir, cpg_ids: list[str]):
                 out_file.write(chrom_line)
                 # Write GT or lines containing the calls
                 out_file.writelines(gt_lines)
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -67,8 +67,8 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_set, variant_id_order
             elif not line.startswith('#'):
                 # Collect calls after #CHROM
                 row_info = line.split('\t')[7]
-                #var_id = {(row_info.split(';')[4])[6:]}
-                print(f'var_id to intersect: {var_id}')
+                var_id = {(row_info.split(';')[4])[6:]}
+                #print(f'var_id to intersect: {var_id}')
                 if var_id & variant_id_set:
                     var_id = ''.join(map(str, var_id))
                     gt_lines[var_id] = line

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -75,7 +75,7 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_set, variant_id_order
     sorted_alt_lines = sorted(alt_lines)
 
     # sort gt_lines by variant ID
-    sorted_gt = {key: gt_lines[key] for key in variant_id_order if key in gt_lines}
+    sorted_gt = {key: gt_lines[{key}] for key in variant_id_order if key in gt_lines}
     print (f'Parsed {len(sorted_gt)} variants from {cpg_id} shard {chunk_number}')
 
     # Write the combined information to the output file

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -79,7 +79,7 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_set, variant_id_order
     print(f'gt_lines length: {len(gt_lines)}')
 
     # sort gt_lines by variant ID
-    sorted_gt = {key: gt_lines[key] for key in variant_id_order}
+    sorted_gt = {key: gt_lines[key] for key in variant_id_order if key in gt_lines}
     print (f'Parsed {len(sorted_gt)} variants from {cpg_id} shard {chunk_number}')
 
     #debug

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -67,7 +67,7 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_set, variant_id_order
             elif not line.startswith('#'):
                 # Collect calls after #CHROM
                 row_info = line.split('\t')[7]
-                var_id = {(row_info.split(';')[4])[6:]}
+                #var_id = {(row_info.split(';')[4])[6:]}
                 print(f'var_id to intersect: {var_id}')
                 if var_id & variant_id_set:
                     var_id = ''.join(map(str, var_id))

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -69,14 +69,10 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_order):
             elif not line.startswith('#'):
                 # Collect calls after #CHROM
                 row_info = line.split('\t')[7]
-                var_id = {(row_info.split(';')[4])[6:]}
+                var_id = row_info.split(';')[4].removeprefix('VARID=')
 
-                if (
-                    var_id & variant_id_set
-                ):  # if the variant ID is in the set of target variant IDs
-                    var_id = ''.join(
-                        map(str, var_id)
-                    )  # converts var_id from set to string
+                # if the variant ID is in the set of target variant IDs
+                if var_id in variant_id_set:
                     gt_lines[var_id] = line
 
     # Sort ALT lines alphabetically and convert to a list

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -120,7 +120,7 @@ def main(json_file_dir, vcf_file_dir, cpg_ids: list[str]):
         for cpg_id in cpg_ids:
             # make input_files GSPath elements into a string type object
             vcf_file_path = f'{vcf_file_dir}/{cpg_id}_combined.vcf'
-            chunk_number = catalog_file.split('/')[-1].split('_')[1].split('.')[0]
+            chunk_number = catalog_file.split('/')[-1].split('shard')[1].split('.')[0]
             vcf_pruner_job = b.new_python_job(
                 name=f'VCF Combiner job: {cpg_id} chunk {chunk_number}'
             )

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -31,7 +31,7 @@ def variant_id_collector(catalog_file):
         for line in f:
             if not line.startswith('#'):
                 row_info = line.split('\t')[7]
-                var_id = {(row_info.split(';')[4])[6:]}
+                var_id = (row_info.split(';')[4])[6:]
                 variant_ids.append(var_id)
 
     return set(variant_ids)

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -68,6 +68,7 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_set, variant_id_order
                 # Collect calls after #CHROM
                 row_info = line.split('\t')[7]
                 var_id = {(row_info.split(';')[4])[6:]}
+                print(f'var_id to intersect: {var_id}')
                 if var_id & variant_id_set:
                     var_id = ''.join(map(str, var_id))
                     gt_lines[var_id] = line
@@ -76,6 +77,7 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_set, variant_id_order
     sorted_alt_lines = sorted(alt_lines)
 
     #debug
+    print(f'variant_id_set:    {variant_id_set}')
     print(f'gt_lines length: {len(gt_lines)}')
 
     # sort gt_lines by variant ID

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -75,7 +75,8 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_set, variant_id_order
     sorted_alt_lines = sorted(alt_lines)
 
     # sort gt_lines by variant ID
-    sorted_gt = {key: gt_lines[key] for key in variant_id_order}
+    sorted_gt = {key: gt_lines[key] for key in variant_id_order if key in gt_lines}
+    print (f'Parsed {len(sorted_gt)} variants from {cpg_id} shard {chunk_number}')
 
     # Write the combined information to the output file
     gcs_out_path = output_path(f'{cpg_id}/{cpg_id}_eh_shard{chunk_number}.vcf')

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -108,5 +108,6 @@ def main(json_file_dir, vcf_file_dir, cpg_ids: list[str]):
                 # Write GT or lines containing the calls
                 out_file.writelines(gt_lines)
 
+
 if __name__ == '__main__':
     main()  # pylint: disable=no-value-for-parameter

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -22,67 +22,88 @@ config = get_config()
 
 @click.command()
 @click.option(
-    '--json-file-path',
+    '--json-file-dir',
     help='Parent input directory for sharded VCFs (subfolders should be labelled with CPG ID)',
 )
 @click.option(
-    '--vcf-file-path',
-    help='GCS path to the VCF file to be pruned',
+    '--vcf-file-dir',
+    help='GCS path to folder containg the VCF file(s) to be pruned',
 )
+@click.argument('cpg-ids', nargs=-1)
 
-def main(json_file_path, vcf_file_path):
-    with to_path(json_file_path).open('r') as json_file:
-        # Load the JSON content
-        catalog = json.load(json_file)
+def main(json_file_dir, vcf_file_dir, cpg_ids: list[str]):
 
-    for entry in catalog:
-        # Check if 'VariantId' exists, use 'LocusId' otherwise
-        entry_variant_ids = (
-            set(entry['VariantId']) if 'VariantId' in entry else {entry['LocusId']}
-        )
-    # Initialize variables to store information
-    fileformat_line = ''
-    info_lines = []
-    alt_lines = set()
-    chrom_line = ''
-    gt_lines = []
+    # list of catalog files (multiple, if catalog is sharded)
+    catalog_files = list(to_path(json_file_dir).glob('*.json'))
+    catalog_files = [
+        str(gs_path) for gs_path in catalog_files
+    ]  # coverts into a string type
+    for catalog_file in catalog_files:
+        variant_ids= []
 
-    with to_path(vcf_file_path).open() as f:
-        for line in f:
-            # Collect information from the header lines
-            if line.startswith('##fileformat'):
-                fileformat_line = line
-            elif (
-                line.startswith('##INFO')
-                or line.startswith('##FILTER')
-                or line.startswith('##FORMAT')
-            ):
+        with to_path(catalog_file).open('r') as json_file:
+            # Load the JSON content
+            catalog = json.load(json_file)
 
-                info_lines.append(line)
-            elif line.startswith('##ALT'):
-                # Collect ALT lines from all files into a set to remove duplicates
-                alt_lines.add(line)
-            elif line.startswith('#CHROM'):
-                chrom_line = line
-            elif not line.startswith('#'):
-                # Collect calls after #CHROM
-                row_info = line.split('\t')[7]
-                var_id = row_info.split(';')[4][6:]
-                if var_id in entry_variant_ids:
-                    gt_lines.append(line)
+            for entry in catalog:
+                # Check if 'VariantId' exists, use 'LocusId' otherwise
+                entry_variant_ids = (
+                    entry['VariantId'] if 'VariantId' in entry else [entry['LocusId']]
+                )
+                variant_ids.extend(entry_variant_ids)
+        variant_ids = set(variant_ids)
 
-    # Sort ALT lines alphabetically and convert to a list
-    sorted_alt_lines = sorted(alt_lines)
 
-    # Write the combined information to the output file
-    with to_path(gcs_out_path).open('w') as out_file:
-        # Write fileformat line
-        out_file.write(fileformat_line)
-        # Write INFO, FILTER, and FORMAT lines
-        out_file.writelines(info_lines)
-        # Write ALT lines
-        out_file.writelines(sorted_alt_lines)
-        # Write CHROM line
-        out_file.write(chrom_line)
-        # Write GT or lines containing the calls
-        out_file.writelines(gt_lines)
+        # Initialize variables to store information
+        fileformat_line = ''
+        info_lines = []
+        alt_lines = set()
+        chrom_line = ''
+        gt_lines = []
+
+        for cpg_id in cpg_ids:
+            # make input_files GSPath elements into a string type object
+            vcf_file_path = f'{vcf_file_dir}/{cpg_id}_combined.vcf'
+            # Process each input file
+
+            with to_path(vcf_file_path).open() as f:
+                for line in f:
+                    # Collect information from the header lines
+                    if line.startswith('##fileformat'):
+                        fileformat_line = line
+                    elif (
+                        line.startswith('##INFO')
+                        or line.startswith('##FILTER')
+                        or line.startswith('##FORMAT')
+                    ):
+
+                        info_lines.append(line)
+                    elif line.startswith('##ALT'):
+                        # Collect ALT lines from all files into a set to remove duplicates
+                        alt_lines.add(line)
+                    elif line.startswith('#CHROM'):
+                        chrom_line = line
+                    elif not line.startswith('#'):
+                        # Collect calls after #CHROM
+                        row_info = line.split('\t')[7]
+                        var_id = {(row_info.split(';')[4])[6:]}
+                        if var_id & variant_ids:
+                            gt_lines.append(line)
+
+            # Sort ALT lines alphabetically and convert to a list
+            sorted_alt_lines = sorted(alt_lines)
+
+            # Write the combined information to the output file
+            chunk_number = catalog_file.split('/')[-1].split('_')[1].split('.')[0]
+            gcs_out_path = output_path(f'{cpg_id}/{cpg_id}_eh_shard{chunk_number}.vcf')
+            with to_path(gcs_out_path).open('w') as out_file:
+                # Write fileformat line
+                out_file.write(fileformat_line)
+                # Write INFO, FILTER, and FORMAT lines
+                out_file.writelines(info_lines)
+                # Write ALT lines
+                out_file.writelines(sorted_alt_lines)
+                # Write CHROM line
+                out_file.write(chrom_line)
+                # Write GT or lines containing the calls
+                out_file.writelines(gt_lines)

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -75,9 +75,16 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_set, variant_id_order
     # Sort ALT lines alphabetically and convert to a list
     sorted_alt_lines = sorted(alt_lines)
 
+    #debug
+    print(f'gt_lines length: {len(gt_lines)}')
+
     # sort gt_lines by variant ID
-    sorted_gt = {key: gt_lines[key] for key in variant_id_order if key in gt_lines}
+    sorted_gt = {key: gt_lines[key] for key in variant_id_order}
     print (f'Parsed {len(sorted_gt)} variants from {cpg_id} shard {chunk_number}')
+
+    #debug
+    print(f'sorted_gt: {sorted_gt}')
+    print(f'variant_id_order: {variant_id_order}')
 
     # Write the combined information to the output file
     gcs_out_path = output_path(f'{cpg_id}/{cpg_id}_eh_shard{chunk_number}.vcf')

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
 
 """
-This script prunes a VCF file, removing all variants that are not present in a provided sharded catalog.
-The output is a pruned VCF file, sharded in the same way as the input catalog, output to a GCS bucket.
+This script prunes a VCF file (vcf-file-dir), removing all variants that are not present in a separate provided sharded VCF (vcf-catalog-dir).
+This script assumes that the input VCF file to be pruned contains variants that are a super-set of the variants in vcf-catalog-dir.
 
-Option to provide multiple samples and create pruned sharded VCFs for each sample.
+The output is a pruned VCF file, sharded in the same way as the files in vcf-catalog-dir, output to a GCS bucket.
+
+Optional to provide multiple samples and create pruned sharded VCFs for each sample.
 
 analysis-runner --access-level test --dataset tob-wgs --description \
     'VCF pruner' --output-dir 'str/5M_run_combined_vcfs_pruned/v2' \
     vcf_pruner.py \
-    --json-file-dir=gs://cpg-tob-wgs-test/str/5M_3M_merge_experiment/3M/CPG308296 \
-    --vcf-file-dir=gs://cpg-tob-wgs-test/str/5M_3M_merge_experiment CPG308288
+    --vcf-catalog-dir=gs://cpg-tob-wgs-test/str/5M_3M_merge_experiment/3M/CPGXXX \
+    --vcf-file-dir=gs://cpg-tob-wgs-test/str/5M_3M_merge_experiment CPGXXXXX
 """
 import click
 
@@ -22,15 +24,17 @@ config = get_config()
 
 
 def variant_id_collector(catalog_file):
-    """Collects all variant IDs from a sharded catalog file and returns a set of unique variant IDs."""
+    """Collects all variant IDs from a sharded VCF file and returns a list of variant IDs."""
 
     variant_ids = []
 
     with to_path(catalog_file).open() as f:
         for line in f:
             if not line.startswith('#'):
+                # wrangle variant ID from INFO column, assumes ExpansionHunter VCF format
                 row_info = line.split('\t')[7]
                 var_id = (row_info.split(';')[4])[6:]
+
                 variant_ids.append(var_id)
 
     return variant_ids
@@ -45,7 +49,8 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_order):
     info_lines = []
     alt_lines = set()
     chrom_line = ''
-    gt_lines = {}
+    gt_lines = {}  # key = variant ID, value = line in VCF containing GT
+    # set structure allows for faster intersection
     variant_id_set = set(variant_id_order)
 
     with to_path(vcf_file_path).open() as f:
@@ -69,18 +74,21 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_order):
                 # Collect calls after #CHROM
                 row_info = line.split('\t')[7]
                 var_id = {(row_info.split(';')[4])[6:]}
-                if var_id & variant_id_set:
-                    var_id = ''.join(map(str, var_id))
+
+                if (
+                    var_id & variant_id_set
+                ):  # if the variant ID is in the set of target variant IDs
+                    var_id = ''.join(
+                        map(str, var_id)
+                    )  # converts var_id from set to string
                     gt_lines[var_id] = line
 
     # Sort ALT lines alphabetically and convert to a list
     sorted_alt_lines = sorted(alt_lines)
 
-
-    # sort gt_lines by variant ID
+    # sort gt_lines by variant ID in the order provided by variant_id_order
     sorted_gt = {key: gt_lines[key] for key in variant_id_order if key in gt_lines}
-    print (f'Parsed {len(sorted_gt)} variants from {cpg_id} shard {chunk_number}')
-
+    print(f'Parsed {len(sorted_gt)} variants from {cpg_id} shard {chunk_number}')
 
     # Write the combined information to the output file
     gcs_out_path = output_path(f'{cpg_id}/{cpg_id}_eh_shard{chunk_number}.vcf')
@@ -99,21 +107,21 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_order):
 
 @click.command()
 @click.option(
-    '--json-file-dir',
-    help='Parent input directory for sharded VCFs (subfolders should be labelled with CPG ID)',
+    '--vcf-catalog-dir',
+    help='Parent input directory for sharded VCFs containing target variants (subfolders should be labelled with CPG ID)',
 )
 @click.option(
     '--vcf-file-dir',
     help='GCS path to folder containg the VCF file(s) to be pruned',
 )
 @click.argument('cpg-ids', nargs=-1)
-def main(json_file_dir, vcf_file_dir, cpg_ids: list[str]):
+def main(vcf_catalog_dir, vcf_file_dir, cpg_ids: list[str]):
     """Prunes a VCF file, removing all variants that are not present in a provided sharded VCF."""
     # Initializing Batch
     b = get_batch()
 
     # list of catalog files (multiple, if catalog is sharded)
-    catalog_files = list(to_path(json_file_dir).glob('*.vcf'))
+    catalog_files = list(to_path(vcf_catalog_dir).glob('*.vcf'))
     catalog_files = [
         str(gs_path) for gs_path in catalog_files
     ]  # coverts into a string type
@@ -121,21 +129,22 @@ def main(json_file_dir, vcf_file_dir, cpg_ids: list[str]):
         variant_id_collector_job = b.new_python_job(
             name=f'Variant ID collector job: {catalog_file}'
         )
-        variant_id_collector_job.memory('16G')
-        variant_id_collector_job.storage('20G')
+        variant_id_collector_job.memory('8G')
+        variant_id_collector_job.storage('10G')
         variant_id_order = variant_id_collector_job.call(
             variant_id_collector, catalog_file
         )
 
         for cpg_id in cpg_ids:
-            # make input_files GSPath elements into a string type object
+
             vcf_file_path = f'{vcf_file_dir}/{cpg_id}_combined.vcf'
+            # extract shard number from the VCF file name
             chunk_number = catalog_file.split('/')[-1].split('shard')[1].split('.')[0]
             vcf_pruner_job = b.new_python_job(
                 name=f'VCF Combiner job: {cpg_id} chunk {chunk_number}'
             )
-            vcf_pruner_job.memory('16G')
-            vcf_pruner_job.storage('20G')
+            vcf_pruner_job.memory('8G')
+            vcf_pruner_job.storage('10G')
             vcf_pruner_job.call(
                 pruner,
                 vcf_file_path,

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+"""
+This script prunes a VCF file, removing all variants that are not present in a provided sharded catalog.
+The output is a pruned VCF file, sharded in the same way as the input catalog, output to a GCS bucket.
+
+analysis-runner --access-level test --dataset tob-wgs --description \
+    'VCF combiner' --output-dir 'str/5M_run_combined_vcfs' \
+    vcf_combiner.py \
+    --input-dir=gs://cpg-tob-wgs-test/hoptan-str \
+    sharded_tester
+"""
+
+import click
+import json
+
+from cpg_utils.config import get_config
+from cpg_utils import to_path
+from cpg_utils.hail_batch import get_batch, output_path
+
+config = get_config()
+
+@click.command()
+@click.option(
+    '--json-file-path',
+    help='Parent input directory for sharded VCFs (subfolders should be labelled with CPG ID)',
+)
+@click.option(
+    '--vcf-file-path',
+    help='GCS path to the VCF file to be pruned',
+)
+
+def main(json_file_path, vcf_file_path):
+    with to_path(json_file_path).open('r') as json_file:
+        # Load the JSON content
+        catalog = json.load(json_file)
+
+    for entry in catalog:
+        # Check if 'VariantId' exists, use 'LocusId' otherwise
+        entry_variant_ids = (
+            set(entry['VariantId']) if 'VariantId' in entry else {entry['LocusId']}
+        )
+    # Initialize variables to store information
+    fileformat_line = ''
+    info_lines = []
+    alt_lines = set()
+    chrom_line = ''
+    gt_lines = []
+
+    with to_path(vcf_file_path).open() as f:
+        for line in f:
+            # Collect information from the header lines
+            if line.startswith('##fileformat'):
+                fileformat_line = line
+            elif (
+                line.startswith('##INFO')
+                or line.startswith('##FILTER')
+                or line.startswith('##FORMAT')
+            ):
+
+                info_lines.append(line)
+            elif line.startswith('##ALT'):
+                # Collect ALT lines from all files into a set to remove duplicates
+                alt_lines.add(line)
+            elif line.startswith('#CHROM'):
+                chrom_line = line
+            elif not line.startswith('#'):
+                # Collect calls after #CHROM
+                row_info = line.split('\t')[7]
+                var_id = row_info.split(';')[4][6:]
+                if var_id in entry_variant_ids:
+                    gt_lines.append(line)
+
+    # Sort ALT lines alphabetically and convert to a list
+    sorted_alt_lines = sorted(alt_lines)
+
+    # Write the combined information to the output file
+    with to_path(gcs_out_path).open('w') as out_file:
+        # Write fileformat line
+        out_file.write(fileformat_line)
+        # Write INFO, FILTER, and FORMAT lines
+        out_file.writelines(info_lines)
+        # Write ALT lines
+        out_file.writelines(sorted_alt_lines)
+        # Write CHROM line
+        out_file.write(chrom_line)
+        # Write GT or lines containing the calls
+        out_file.writelines(gt_lines)

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -36,7 +36,7 @@ def variant_id_collector(catalog_file):
     return variant_ids
 
 
-def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_set, variant_id_order):
+def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_order):
     """Prunes a VCF file, removing all variants that are not present in the list of provided variant IDs.
     Writes output to GCS bucket.
     """
@@ -46,6 +46,7 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_set, variant_id_order
     alt_lines = set()
     chrom_line = ''
     gt_lines = {}
+    variant_id_set = set(variant_id_order)
 
     with to_path(vcf_file_path).open() as f:
         for line in f:
@@ -132,7 +133,6 @@ def main(json_file_dir, vcf_file_dir, cpg_ids: list[str]):
         variant_id_order = variant_id_collector_job.call(
             variant_id_collector, catalog_file
         )
-        variant_id_set = set(variant_id_order)
 
         for cpg_id in cpg_ids:
             # make input_files GSPath elements into a string type object
@@ -148,7 +148,6 @@ def main(json_file_dir, vcf_file_dir, cpg_ids: list[str]):
                 vcf_file_path,
                 cpg_id,
                 chunk_number,
-                variant_id_set,
                 variant_id_order,
             )
 

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -16,11 +16,8 @@ analysis-runner --access-level test --dataset tob-wgs --description \
 """
 import click
 
-from cpg_utils.config import get_config
 from cpg_utils import to_path
 from cpg_utils.hail_batch import get_batch, output_path
-
-config = get_config()
 
 
 def variant_id_collector(catalog_file):
@@ -63,7 +60,6 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_order):
                 or line.startswith('##FILTER')
                 or line.startswith('##FORMAT')
             ):
-
                 info_lines.append(line)
             elif line.startswith('##ALT'):
                 # Collect ALT lines from all files into a set to remove duplicates
@@ -136,7 +132,6 @@ def main(vcf_catalog_dir, vcf_file_dir, cpg_ids: list[str]):
         )
 
         for cpg_id in cpg_ids:
-
             vcf_file_path = f'{vcf_file_dir}/{cpg_id}_eh.vcf'
             # extract shard number from the VCF file name
             chunk_number = catalog_file.split('/')[-1].split('shard')[1].split('.')[0]

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -117,8 +117,8 @@ def main(json_file_dir, vcf_file_dir, cpg_ids: list[str]):
         variant_id_collector_job = b.new_python_job(
             name=f'Variant ID collector job: {catalog_file}'
         )
-        vcf_pruner_job.memory('16G')
-        vcf_pruner_job.storage('20G')
+        variant_id_collector_job.memory('16G')
+        variant_id_collector_job.storage('20G')
         variant_ids = variant_id_collector_job.call(variant_id_collector, catalog_file)
 
         for cpg_id in cpg_ids:

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -137,7 +137,7 @@ def main(vcf_catalog_dir, vcf_file_dir, cpg_ids: list[str]):
 
         for cpg_id in cpg_ids:
 
-            vcf_file_path = f'{vcf_file_dir}/{cpg_id}_combined.vcf'
+            vcf_file_path = f'{vcf_file_dir}/{cpg_id}_eh.vcf'
             # extract shard number from the VCF file name
             chunk_number = catalog_file.split('/')[-1].split('shard')[1].split('.')[0]
             vcf_pruner_job = b.new_python_job(

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -69,13 +69,14 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_set, variant_id_order
                 row_info = line.split('\t')[7]
                 var_id = {(row_info.split(';')[4])[6:]}
                 if var_id & variant_id_set:
+                    var_id = ''.join(map(str, var_id))
                     gt_lines[var_id] = line
 
     # Sort ALT lines alphabetically and convert to a list
     sorted_alt_lines = sorted(alt_lines)
 
     # sort gt_lines by variant ID
-    sorted_gt = {key: gt_lines[{key}] for key in variant_id_order if key in gt_lines}
+    sorted_gt = {key: gt_lines[key] for key in variant_id_order if key in gt_lines}
     print (f'Parsed {len(sorted_gt)} variants from {cpg_id} shard {chunk_number}')
 
     # Write the combined information to the output file

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -12,7 +12,7 @@ analysis-runner --access-level test --dataset tob-wgs --description \
     'VCF pruner' --output-dir 'str/5M_run_combined_vcfs_pruned/v2' \
     vcf_pruner.py \
     --vcf-catalog-dir=gs://cpg-tob-wgs-test/str/5M_3M_merge_experiment/3M/CPGXXX \
-    --vcf-file-dir=gs://cpg-tob-wgs-test/str/5M_3M_merge_experiment CPGXXXXX
+    --vcf-file-dir=gs://cpg-tob-wgs-test/str/5M_3M_merge_experiment CPGXX
 """
 import click
 
@@ -132,7 +132,7 @@ def main(vcf_catalog_dir, vcf_file_dir, cpg_ids: list[str]):
             # extract shard number from the VCF file name
             chunk_number = catalog_file.split('/')[-1].split('shard')[1].split('.')[0]
             vcf_pruner_job = b.new_python_job(
-                name=f'VCF Combiner job: {cpg_id} chunk {chunk_number}'
+                name=f'VCF pruner job: {cpg_id} chunk {chunk_number}'
             )
             vcf_pruner_job.memory('8G')
             vcf_pruner_job.storage('10G')

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -69,7 +69,6 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_order):
                 # Collect calls after #CHROM
                 row_info = line.split('\t')[7]
                 var_id = {(row_info.split(';')[4])[6:]}
-                #print(f'var_id to intersect: {var_id}')
                 if var_id & variant_id_set:
                     var_id = ''.join(map(str, var_id))
                     gt_lines[var_id] = line
@@ -77,17 +76,11 @@ def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_order):
     # Sort ALT lines alphabetically and convert to a list
     sorted_alt_lines = sorted(alt_lines)
 
-    #debug
-    print(f'variant_id_set:    {variant_id_set}')
-    print(f'gt_lines length: {len(gt_lines)}')
 
     # sort gt_lines by variant ID
     sorted_gt = {key: gt_lines[key] for key in variant_id_order if key in gt_lines}
     print (f'Parsed {len(sorted_gt)} variants from {cpg_id} shard {chunk_number}')
 
-    #debug
-    print(f'sorted_gt: {sorted_gt}')
-    print(f'variant_id_order: {variant_id_order}')
 
     # Write the combined information to the output file
     gcs_out_path = output_path(f'{cpg_id}/{cpg_id}_eh_shard{chunk_number}.vcf')

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -33,7 +33,7 @@ def variant_id_collector(catalog_file):
                 var_id = (row_info.split(';')[4])[6:]
                 variant_ids.append(var_id)
 
-    return set(variant_ids), variant_ids
+    return variant_ids
 
 
 def pruner(vcf_file_path, cpg_id, chunk_number, variant_id_set, variant_id_order):
@@ -118,9 +118,10 @@ def main(json_file_dir, vcf_file_dir, cpg_ids: list[str]):
         )
         variant_id_collector_job.memory('16G')
         variant_id_collector_job.storage('20G')
-        variant_id_set, variant_id_order = variant_id_collector_job.call(
+        variant_id_order = variant_id_collector_job.call(
             variant_id_collector, catalog_file
         )
+        variant_id_set = set(variant_id_order)
 
         for cpg_id in cpg_ids:
             # make input_files GSPath elements into a string type object

--- a/str/helper/vcf_pruner.py
+++ b/str/helper/vcf_pruner.py
@@ -17,9 +17,80 @@ import click
 
 from cpg_utils.config import get_config
 from cpg_utils import to_path
-from cpg_utils.hail_batch import output_path
+from cpg_utils.hail_batch import get_batch, output_path
 
 config = get_config()
+
+def variant_id_collector(catalog_file):
+    """Collects all variant IDs from a sharded catalog file and returns a set of unique variant IDs."""
+
+    variant_ids = []
+
+    with to_path(catalog_file).open('r') as json_file:
+        # Load the JSON content
+        catalog = json.load(json_file)
+
+        for entry in catalog:
+            # Check if 'VariantId' exists, use 'LocusId' otherwise
+            entry_variant_ids = (
+                entry['VariantId'] if 'VariantId' in entry else [entry['LocusId']]
+            )
+            variant_ids.extend(entry_variant_ids)
+    return set(variant_ids)
+
+
+def pruner(vcf_file_path, cpg_id, chunk_number, variant_ids):
+    """Prunes a VCF file, removing all variants that are not present in the list of provided variant IDs.
+    Writes output to GCS bucket.
+    """
+    # Initialize variables to store information
+    fileformat_line = ''
+    info_lines = []
+    alt_lines = set()
+    chrom_line = ''
+    gt_lines = []
+
+    with to_path(vcf_file_path).open() as f:
+        for line in f:
+            # Collect information from the header lines
+            if line.startswith('##fileformat'):
+                fileformat_line = line
+            elif (
+                line.startswith('##INFO')
+                or line.startswith('##FILTER')
+                or line.startswith('##FORMAT')
+            ):
+
+                info_lines.append(line)
+            elif line.startswith('##ALT'):
+                # Collect ALT lines from all files into a set to remove duplicates
+                alt_lines.add(line)
+            elif line.startswith('#CHROM'):
+                chrom_line = line
+            elif not line.startswith('#'):
+                # Collect calls after #CHROM
+                row_info = line.split('\t')[7]
+                var_id = {(row_info.split(';')[4])[6:]}
+                if var_id & variant_ids:
+                    gt_lines.append(line)
+
+    # Sort ALT lines alphabetically and convert to a list
+    sorted_alt_lines = sorted(alt_lines)
+
+    # Write the combined information to the output file
+    gcs_out_path = output_path(f'{cpg_id}/{cpg_id}_eh_shard{chunk_number}.vcf')
+    with to_path(gcs_out_path).open('w') as out_file:
+        # Write fileformat line
+        out_file.write(fileformat_line)
+        # Write INFO, FILTER, and FORMAT lines
+        out_file.writelines(info_lines)
+        # Write ALT lines
+        out_file.writelines(sorted_alt_lines)
+        # Write CHROM line
+        out_file.write(chrom_line)
+        # Write GT or lines containing the calls
+        out_file.writelines(gt_lines)
+
 
 
 @click.command()
@@ -34,80 +105,31 @@ config = get_config()
 @click.argument('cpg-ids', nargs=-1)
 def main(json_file_dir, vcf_file_dir, cpg_ids: list[str]):
     """Prunes a VCF file, removing all variants that are not present in a provided sharded catalog."""
+    # Initializing Batch
+    b = get_batch()
+
     # list of catalog files (multiple, if catalog is sharded)
     catalog_files = list(to_path(json_file_dir).glob('*.json'))
     catalog_files = [
         str(gs_path) for gs_path in catalog_files
     ]  # coverts into a string type
     for catalog_file in catalog_files:
-        variant_ids = []
+        variant_id_collector_job = b.new_python_job(name=f'Variant ID collector job: {catalog_file}')
+        vcf_pruner_job.memory('16G')
+        vcf_pruner_job.storage('20G')
+        variant_ids = variant_id_collector_job.call(variant_id_collector, catalog_file)
 
-        with to_path(catalog_file).open('r') as json_file:
-            # Load the JSON content
-            catalog = json.load(json_file)
-
-            for entry in catalog:
-                # Check if 'VariantId' exists, use 'LocusId' otherwise
-                entry_variant_ids = (
-                    entry['VariantId'] if 'VariantId' in entry else [entry['LocusId']]
-                )
-                variant_ids.extend(entry_variant_ids)
-        variant_ids = set(variant_ids)
-
-        # Initialize variables to store information
-        fileformat_line = ''
-        info_lines = []
-        alt_lines = set()
-        chrom_line = ''
-        gt_lines = []
 
         for cpg_id in cpg_ids:
             # make input_files GSPath elements into a string type object
             vcf_file_path = f'{vcf_file_dir}/{cpg_id}_combined.vcf'
-            # Process each input file
-
-            with to_path(vcf_file_path).open() as f:
-                for line in f:
-                    # Collect information from the header lines
-                    if line.startswith('##fileformat'):
-                        fileformat_line = line
-                    elif (
-                        line.startswith('##INFO')
-                        or line.startswith('##FILTER')
-                        or line.startswith('##FORMAT')
-                    ):
-
-                        info_lines.append(line)
-                    elif line.startswith('##ALT'):
-                        # Collect ALT lines from all files into a set to remove duplicates
-                        alt_lines.add(line)
-                    elif line.startswith('#CHROM'):
-                        chrom_line = line
-                    elif not line.startswith('#'):
-                        # Collect calls after #CHROM
-                        row_info = line.split('\t')[7]
-                        var_id = {(row_info.split(';')[4])[6:]}
-                        if var_id & variant_ids:
-                            gt_lines.append(line)
-
-            # Sort ALT lines alphabetically and convert to a list
-            sorted_alt_lines = sorted(alt_lines)
-
-            # Write the combined information to the output file
             chunk_number = catalog_file.split('/')[-1].split('_')[1].split('.')[0]
-            gcs_out_path = output_path(f'{cpg_id}/{cpg_id}_eh_shard{chunk_number}.vcf')
-            with to_path(gcs_out_path).open('w') as out_file:
-                # Write fileformat line
-                out_file.write(fileformat_line)
-                # Write INFO, FILTER, and FORMAT lines
-                out_file.writelines(info_lines)
-                # Write ALT lines
-                out_file.writelines(sorted_alt_lines)
-                # Write CHROM line
-                out_file.write(chrom_line)
-                # Write GT or lines containing the calls
-                out_file.writelines(gt_lines)
+            vcf_pruner_job = b.new_python_job(name=f'VCF Combiner job: {cpg_id} chunk {chunk_number}')
+            vcf_pruner_job.memory('16G')
+            vcf_pruner_job.storage('20G')
+            vcf_pruner_job.call(pruner, vcf_file_path, cpg_id, chunk_number, variant_ids)
 
+    b.run(wait=False)
 
 if __name__ == '__main__':
     main()  # pylint: disable=no-value-for-parameter

--- a/str/trtools/merge_str_runner.py
+++ b/str/trtools/merge_str_runner.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
+# pylint: disable=too-many-arguments,too-many-locals
 """
 This script merges ExpansionHunter vcf.gz files into one combined VCF.
 Please ensure merge_prep.py has been run on the vcf files prior to running mergeSTR.py
 
-Optional ability to add in VCFs from another file directory (but must be sharded in the same way as the input-dir-1)
+Optional ability to add in VCFs from another file directory (but must be sharded in the same way)
+Specify VCFs from each distinct file directory as a comma separated list of the input directory and the sample list file (in that order) eg: input-dir-1,sample-1 input-dir-2,sample-2
 
 For example:
-analysis-runner --access-level standard --dataset tob-wgs --description '5M merge TOB100' --output-dir 'str/5M_run_combined_vcfs/merge_str/v4' merge_str_runner.py --input-dir-1=gs://cpg-tob-wgs-main-analysis/str/5M_run_combined_vcfs/merge_str_prep/v4-2 --num-shards=50 --sample-list-1=gs://
+analysis-runner --access-level full --dataset tob-wgs --description '5M-3M mergeSTR tester' --output-dir 'str/5M-3M experiment/merge_str/v1' merge_str_runner.py --num-shards=27 \
+gs://cpg-tob-wgs-main-analysis/str/5M_run_combined_vcfs_pruned/merge_str_prep/v4,gs://cpg-tob-wgs-test/str/polymorphic_run/mergeSTR-tester-5M.txt \
+gs://cpg-tob-wgs-main-analysis/str/polymorphic_run/merge_str_prep/v1,gs://cpg-tob-wgs-test/str/polymorphic_run/mergeSTR-tester-3M.txt
 
 Required packages: sample-metadata, hail, click, os
 pip install sample-metadata hail click
@@ -26,17 +30,7 @@ TRTOOLS_IMAGE = config['images']['trtools']
 
 
 # inputs:
-
-
-# input directory 1
-@click.option('--input-dir-1', help='gs://...')
-# input directory 2
-@click.option('--input-dir-2', help='gs://...', default=None)
-# sample list 1 (CPG sample IDs separated by \n)
-@click.option('--sample-list-1', help='gs://...')
-# sample list 2 (CPG sample IDs separated by \n)
-@click.option('--sample-list-2', help='gs://...', default=None)
-# input num shards
+# num shards
 @click.option(
     '--num-shards',
     type=int,
@@ -46,9 +40,17 @@ TRTOOLS_IMAGE = config['images']['trtools']
 @click.option(
     '--job-storage', help='Storage of the Hail batch job eg 30G', default='20G'
 )
+@click.option('--job-memory', help='Memory of the Hail batch job', default='standard')
+@click.option('--job-cpu', help='Number of CPUs of the Hail batch job', default=8)
+# input sample ID
+@click.argument('input-file-paths', nargs=-1)
 @click.command()
 def main(
-    job_storage, input_dir_1, input_dir_2, sample_list_1, sample_list_2, num_shards
+    job_storage,
+    job_memory,
+    job_cpu,
+    num_shards,
+    input_file_paths,
 ):  # pylint: disable=missing-function-docstring
     # Initializing Batch
     b = get_batch()
@@ -56,7 +58,8 @@ def main(
         # Initialise TRTools job to run mergeSTR
         trtools_job = b.new_job(name=f'mergeSTR shard {shard_index}')
         trtools_job.image(TRTOOLS_IMAGE)
-        trtools_job.cpu(8)
+        trtools_job.cpu(job_cpu)
+        trtools_job.memory(job_memory)
         trtools_job.storage(job_storage)
         trtools_job.declare_resource_group(
             vcf_output={
@@ -69,29 +72,15 @@ def main(
         # read in input file paths
         batch_vcfs = []
         num_samples = 0
-        with to_path(sample_list_1).open() as f_1:
-            ids_1 = [line.strip() for line in f_1]
-            for id in ids_1:
-                each_vcf = os.path.join(
-                    input_dir_1, f'{id}_eh_shard{shard_index}.reheader.vcf.gz'
-                )
-                batch_vcfs.append(
-                    b.read_input_group(
-                        **{
-                            'vcf.gz': each_vcf,
-                            'vcf.gz.tbi': f'{each_vcf}.tbi',
-                        }
-                    )['vcf.gz']
-                )
-            num_samples = num_samples + len(ids_1)
-
-        # if second file directory is specified, read in input file paths:
-        if input_dir_2 is not None:
-            with to_path(sample_list_2).open() as f_2:
-                ids_2 = [line.strip() for line in f_2]
-                for id in ids_2:
+        cpg_ids = []
+        for pair in input_file_paths:
+            input_dir, sample_list = pair.split(',')
+            with to_path(sample_list).open() as f:
+                ids = [line.strip() for line in f]
+                cpg_ids.extend(ids)
+                for id in ids:
                     each_vcf = os.path.join(
-                        input_dir_2, f'{id}_eh_shard{shard_index}.reheader.vcf.gz'
+                        input_dir, f'{id}_eh_shard{shard_index}.reheader.vcf.gz'
                     )
                     batch_vcfs.append(
                         b.read_input_group(
@@ -101,7 +90,10 @@ def main(
                             }
                         )['vcf.gz']
                     )
-                num_samples = num_samples + len(ids_2)
+                num_samples = num_samples + len(ids)
+
+        if len(cpg_ids) != len(set(cpg_ids)):
+            raise ValueError('Duplicate CPG IDs detected in sample list')
 
         trtools_job.command(
             f"""


### PR DESCRIPTION
I want to create a cleaner solution for merging the VCFs of the subset of samples with extensive genotyping with the rest of the cohort that had fewer loci genotyped (current solution is doing an ad hoc join operation of two matrix tables, but I don't have a solution yet of creating a nice final VCF containing all the samples from both cohorts). The first step is this PR where we prune the extensively genotyped VCFs to contain the variants that match the provided sharded VCF. This is needed because mergeSTR requires VCF inputs to have the same exact catalog of variants (STRs) genotyped. 

The output of this script is that the VCF is sharded to match the way that the provided sharded VCF is sharded; as sharded VCFs are the expected input for downstream mergeSTR step. 

I have tested the output of this script in a simple example with the downstream mergeSTR - works as intended with no errors. 

I don't know why `black` keeps failing :( 