### PR TITLE
Use relative paths for mergeSTR input file arguments

### DIFF
--- a/str/trtools/merge_str_runner.py
+++ b/str/trtools/merge_str_runner.py
@@ -95,9 +95,11 @@ def main(
         if len(cpg_ids) != len(set(cpg_ids)):
             raise ValueError('Duplicate CPG IDs detected in sample list')
 
+        # TODO Convert to use mergeSTR --vcfs-list when that option is available
         trtools_job.command(
             f"""
-        mergeSTR --vcfs {",".join(batch_vcfs)} --out {trtools_job.vcf_output} --vcftype eh
+        cd ${{BATCH_TMPDIR}}
+        mergeSTR --vcfs `(echo {";echo ,".join(batch_vcfs)}) | sed 's|'${{BATCH_TMPDIR}}'/*||' | tr -d '\\n'` --out {trtools_job.vcf_output} --vcftype eh
         bgzip -c {trtools_job.vcf_output}.vcf > {trtools_job.vcf_output['vcf.gz']}
         tabix -f -p vcf {trtools_job.vcf_output['vcf.gz']}  > {trtools_job.vcf_output['vcf.gz.tbi']}
         """

--- a/str/trtools/merge_str_runner.py
+++ b/str/trtools/merge_str_runner.py
@@ -98,8 +98,8 @@ def main(
         # TODO Convert to use mergeSTR --vcfs-list when that option is available
         trtools_job.command(
             f"""
-        cd ${{BATCH_TMPDIR}}
-        mergeSTR --vcfs `(echo {";echo ,".join(batch_vcfs)}) | sed 's|'${{BATCH_TMPDIR}}'/*||' | tr -d '\\n'` --out {trtools_job.vcf_output} --vcftype eh
+        cd ${{BATCH_TMPDIR}}/inputs
+        mergeSTR --vcfs `(echo {";echo ,".join(batch_vcfs)}) | sed 's|'${{BATCH_TMPDIR}}'/inputs/*||' | tr -d '\\n'` --out {trtools_job.vcf_output} --vcftype eh
         bgzip -c {trtools_job.vcf_output}.vcf > {trtools_job.vcf_output['vcf.gz']}
         tabix -f -p vcf {trtools_job.vcf_output['vcf.gz']}  > {trtools_job.vcf_output['vcf.gz.tbi']}
         """


### PR DESCRIPTION
When merging thousands of VCFs, using absolute paths here exceeded the shell's command line length limit. As Hail's input filenames match `${BATCH_TMPDIR}/inputs/…` we can use relative paths by trimming off the leading `${BATCH_TMPDIR}` and so avoid the length limit for longer.

Because Hail uses placeholders in variables like `batch_vcfs` and does not instantiate or expand them until very late in the piece (when the eventual command is written out), we need to do this explicitly in the shell snippet rather than earlier (and more clearly 😢) in Python.

In future, mergeSTR may have a `--vcfs-list` file-list option. When that is released, we will be able to recode this to build a temporary file listing the VCF file names instead.

Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1708146312785919