### PR TITLE
Cp Hail Matrix Table containing STR genotypes into `test` bucket 

### DIFF
--- a/str/helper/cp_mt.sh
+++ b/str/helper/cp_mt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Moves Hail Matrix Table containing STR genotypes into test bucket
+# Copies Hail Matrix Table containing STR genotypes into test bucket
 
 set -ex
 

--- a/str/helper/cp_mt.sh
+++ b/str/helper/cp_mt.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Moves Hail Matrix Table containing STR genotypes into test bucket
+
+set -ex
+
+gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n2045/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n2045/mt/v1/str.mt


### PR DESCRIPTION
Copies Hail Matrix Table containing STR genotypes into `test` bucket for quick iterative QC plot generation. 

Final QC scripts will be merged into `main`, with final QC plots also produced in respective `main-analysis` buckets. At this point, I will delete the mt from `test`