### PR TITLE
Replace `normalize_total` method

### DIFF
--- a/str/associatr/get_cis_numpy_files.py
+++ b/str/associatr/get_cis_numpy_files.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# pylint: disable=too-many-arguments,too-many-locals
+
+"""
+This script aims to:
+ - output gene lists for each cell type and chromosome (after filtering out lowly expressed genes)
+ - output cis window files for each gene with scRNA data (cell type + chr specific)
+ - optionally removes samples based on a provided sample file
+ - perform rank-based inverse normal transformation on pseudobulk data (per gene basis)
+ - output gene-level phenotype and covariate numpy objects for input into associatr
+
+ analysis-runner  --config get_cis_numpy_files.toml --dataset "bioheart" --access-level "test" \
+--description "get cis and numpy" --output-dir "str/associatr/rna_pc_calibration/2_pcs/input_files"  \
+--image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
+python3 get_cis_numpy_files.py
+
+"""
+import json
+from ast import literal_eval
+
+import numpy as np
+import pandas as pd
+import scanpy as sc
+import hail as hl
+import hailtop.batch as hb
+from scipy.stats import norm
+
+
+from cpg_utils.hail_batch import get_batch, output_path, init_batch, image_path
+from cpg_utils.config import get_config
+from cpg_utils import to_path
+
+
+def cis_window_numpy_extractor(
+    input_h5ad_dir,
+    input_pseudobulk_dir,
+    input_cov_dir,
+    chromosome,
+    cell_type,
+    cis_window,
+    version,
+    chrom_len,
+    min_pct,
+    remove_samples_file,
+):
+    """
+    Creates gene-specific cis window files and phenotype-covariate numpy objects
+
+    """
+    init_batch()
+
+    # read in anndata object because anndata.vars has the start, end coordinates of each gene
+    h5ad_file_path = f'{input_h5ad_dir}/{cell_type}_{chromosome}.h5ad'
+    expression_h5ad_path = to_path(h5ad_file_path).copy('here.h5ad')
+    adata = sc.read_h5ad(expression_h5ad_path)
+
+    # read in pseudobulk and covariate files
+    pseudobulk_path = (
+        f'{input_pseudobulk_dir}/{cell_type}/{cell_type}_{chromosome}_pseudobulk.csv'
+    )
+    pseudobulk = pd.read_csv(pseudobulk_path)
+    covariate_path = f'{input_cov_dir}/{cell_type}_covariates.csv'
+    covariates = pd.read_csv(covariate_path)
+
+    # extract genes in pseudobulk df
+    gene_names = list(pseudobulk.columns[1:])  # individual ID is the first column
+
+    # write filtered gene names to a JSON file
+    with to_path(
+        output_path(
+            f'scRNA_gene_lists/{min_pct}_min_pct_cells_expressed/{cell_type}/{chromosome}_{cell_type}_gene_list.json'
+        )
+    ).open('w') as write_handle:
+        json.dump(gene_names, write_handle)
+
+    for gene in gene_names:
+        # get gene body position (start and end) and add window
+        start_coord = adata.var[adata.var.index == gene]['start']
+        end_coord = adata.var[adata.var.index == gene]['end']
+
+        left_boundary = max(1, int(start_coord.iloc[0]) - int(cis_window))
+        right_boundary = min(int(end_coord.iloc[0]) + int(cis_window), chrom_len)
+
+        data = {'chromosome': chromosome, 'start': left_boundary, 'end': right_boundary}
+        ofile_path = output_path(
+            f'cis_window_files/{version}/{cell_type}/{chromosome}/{gene}_{cis_window}bp.bed'
+        )
+        # write cis window file to gcp
+        pd.DataFrame(data, index=[gene]).to_csv(
+            ofile_path, sep='\t', header=False, index=False
+        )
+
+        # make the phenotype-covariate numpy objects
+        pseudobulk.rename(columns={'individual': 'sample_id'}, inplace=True)
+        gene_pheno = pseudobulk[['sample_id', gene]]
+
+        # remove samples that are in the remove_samples_file
+        if remove_samples_file:
+            with to_path(remove_samples_file).open() as f:
+                array_string = f.read().strip()
+                remove_samples = literal_eval(array_string)
+                gene_pheno = gene_pheno[~gene_pheno['sample_id'].isin(remove_samples)]
+
+        # rank-based inverse normal transformation based on R's orderNorm()
+        # Rank the values
+        gene_pheno.loc[:, 'gene_rank'] = gene_pheno[gene].rank()
+        # Calculate the percentile of each rank
+        gene_pheno.loc[:, 'gene_percentile'] = (
+            gene_pheno.loc[:, 'gene_rank'] - 0.5
+        ) / (len(gene_pheno))
+        # Use the inverse normal cumulative distribution function (quantile function) to transform percentiles to normal distribution values
+        gene_pheno.loc[:, 'gene_inverse_normal'] = norm.ppf(
+            gene_pheno.loc[:, 'gene_percentile']
+        )
+        gene_pheno = gene_pheno[['sample_id', 'gene_inverse_normal']]
+
+        gene_pheno_cov = gene_pheno.merge(covariates, on='sample_id', how='inner')
+
+        # filter for samples that were assigned a CPG ID; unassigned samples after demultiplexing will not have a CPG ID
+        gene_pheno_cov = gene_pheno_cov[
+            gene_pheno_cov['sample_id'].str.startswith('CPG')
+        ]
+
+        # add in cohort as a covariate
+        cohort_cpg_id = adata.obs[['cpg_id', 'cohort']]
+        mapping = {'TOB': 1, 'BioHEART': 2}
+        cohort_cpg_id['cohort'] = cohort_cpg_id['cohort'].map(mapping)
+        cohort_cpg_id.rename(columns={'cpg_id': 'sample_id'}, inplace=True)
+        cohort_cpg_id = cohort_cpg_id.drop_duplicates()
+
+        gene_pheno_cov = gene_pheno_cov.merge(
+            cohort_cpg_id, on='sample_id', how='inner'
+        )
+
+        gene_pheno_cov['sample_id'] = gene_pheno_cov['sample_id'].str[
+            3:
+        ]  # remove CPG prefix because associatr expects id to be numeric
+
+        gene_pheno_cov['sample_id'] = gene_pheno_cov['sample_id'].astype(float)
+
+        gene_pheno_cov = gene_pheno_cov.to_numpy()
+        with hl.hadoop_open(
+            output_path(
+                f'pheno_cov_numpy/{version}/{cell_type}/{chromosome}/{gene}_pheno_cov.npy'
+            ),
+            'wb',
+        ) as f:
+            np.save(f, gene_pheno_cov)
+
+
+def main():
+    """
+    Run cis window extraction and phenotype/covariate numpy object creation
+    """
+    b = get_batch(name='get cis_numpy files')
+
+    # Setup MAX concurrency by genes
+    _dependent_jobs: list[hb.batch.job.Job] = []
+
+    def manage_concurrency_for_job(job: hb.batch.job.Job):
+        """
+        To avoid having too many jobs running at once, we have to limit concurrency.
+        """
+        if len(_dependent_jobs) >= get_config()['get_cis_numpy']['max_parallel_jobs']:
+            job.depends_on(
+                _dependent_jobs[-get_config()['get_cis_numpy']['max_parallel_jobs']]
+            )
+        _dependent_jobs.append(job)
+
+    for cell_type in get_config()['get_cis_numpy']['cell_types'].split(','):
+        for chrom in get_config()['get_cis_numpy']['chromosomes'].split(','):
+            init_batch()
+            chrom_len = hl.get_reference('GRCh38').lengths[chrom]
+            j = b.new_python_job(
+                name=f'Extract cis window & phenotype and covariate numpy object for {cell_type}: {chrom}'
+            )
+            j.image(image_path('scanpy'))
+            j.cpu(get_config()['get_cis_numpy']['job_cpu'])
+            j.memory(get_config()['get_cis_numpy']['job_memory'])
+            j.storage(get_config()['get_cis_numpy']['job_storage'])
+            j.call(
+                cis_window_numpy_extractor,
+                get_config()['get_cis_numpy']['input_h5ad_dir'],
+                get_config()['get_cis_numpy']['input_pseudobulk_dir'],
+                get_config()['get_cis_numpy']['input_cov_dir'],
+                chrom,
+                cell_type,
+                get_config()['get_cis_numpy']['cis_window'],
+                get_config()['get_cis_numpy']['version'],
+                chrom_len,
+                get_config()['get_cis_numpy']['min_pct'],
+                get_config()['get_cis_numpy']['remove_samples_file'],
+            )
+
+            manage_concurrency_for_job(j)
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter,too-many-arguments

--- a/str/associatr/get_cis_numpy_files.toml
+++ b/str/associatr/get_cis_numpy_files.toml
@@ -1,0 +1,21 @@
+[get_cis_numpy]
+# GCS directory to the input AnnData objects
+input_h5ad_dir = 'gs://cpg-bioheart-test/str/anndata-240/cpg_anndata/cpg_anndata'
+# GCS directory to the input pseudobulk CSV files
+input_pseudobulk_dir = 'gs://cpg-bioheart-test/str/associatr/input_files/pseudobulk'
+# GCS directory to the input covariate CSV files
+input_cov_dir = 'gs://cpg-bioheart-test/str/associatr/rna_pc_calibration/5_pcs/input_files/covariates/5_rna_pcs'
+chromosomes = 'chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22'
+cell_types = 'CD8_TEM'
+# cis window size in bp
+cis_window = 100000
+version = 'v1'
+job_cpu = 1
+job_memory = 'standard'
+job_storage = '0G'
+# To avoid exceeding Google Cloud quotas, set a concurrency as a limit.
+max_parallel_jobs = 500
+# filter out genes that are expressed in fewer than XX% of cells
+min_pct = 1
+# GCS path to the file containing the list of samples to remove
+remove_samples_file = 'gs://cpg-bioheart-test/str/associatr/input_files/remove-samples.txt'

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+This script calculates cell-type specific PCs from the pseudobulk RNA data (genome-wide),
+merges them with other pre-calculated covariates, and writes the file to GCP.
+
+analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
+--description "Get covariates" --output-dir "str/associatr/rna_pc_calibration/2_pcs/input_files" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/input_files/pseudobulk/pseudobulk \
+--cell-types=CD8_TEM --chromosomes=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 --covariate-file-path=gs://cpg-bioheart-test/str/anndata/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv \
+--num-pcs=2
+
+"""
+
+import logging
+import click
+import pandas as pd
+import scanpy as sc
+import hail as hl
+
+from cpg_utils.hail_batch import output_path, init_batch, get_batch
+from cpg_utils import to_path
+
+
+def get_covariates(
+    pseudobulk_input_dir,
+    cell_type,
+    chromosomes,
+    covariate_file_path,
+    num_pcs,
+):
+    """
+    Calculates cell-type specific PCs from the pseudobulk data (genome-wide),
+    merges them with other pre-calculated covariates, and writes file to GCP
+    """
+    init_batch()
+
+    # read in and concatenate pseudobulk data (chr-specific --> genome-wide anndata)
+    adatas = []
+    for i in chromosomes.split(','):
+        gcs_file_path = (
+            f'{pseudobulk_input_dir}/{cell_type}/{cell_type}_chr{i}_pseudobulk.csv'
+        )
+        print(f'Loading {gcs_file_path}...')
+
+        local_file_path = to_path(gcs_file_path).copy('here.csv')
+        adata = sc.read_csv(local_file_path)
+        adatas.append(adata)
+    adata_genome = sc.concat(adatas, axis=1)
+
+    # subset to high variance genes prior to PCA
+    sc.pp.highly_variable_genes(adata_genome, min_mean=0.0125, max_mean=3, min_disp=0.5)
+    adata_genome = adata_genome[:, adata_genome.var.highly_variable]
+
+    # unit variance scaling for PCA
+    sc.pp.scale(adata_genome, max_value=10)
+
+    # PCA
+    sc.tl.pca(adata_genome, svd_solver='arpack')
+
+    # Variance ratio plot
+    sc.pl.pca_variance_ratio(adata_genome, save='local.png')
+    hl.hadoop_copy(
+        'figures/pca_variance_ratiolocal.png',
+        output_path(f'pseudobulk_RNA_PCs_scree_plots/{cell_type}_scree_plot.png'),
+    )
+
+    # extract PCs
+    df_pcs = pd.DataFrame(adata_genome.obsm['X_pca'])
+    df_pcs.index = adata_genome.obs.index
+    df_pcs = df_pcs.rename_axis(
+        'sample_id'
+    ).reset_index()  # index (CPG ids) are not stored in 'sample_id' column
+    df_pcs = df_pcs[['sample_id'] + list(range(num_pcs))]
+    df_pcs = df_pcs.rename(
+        columns={i: f'rna_PC{i+1}' for i in range(num_pcs)}
+    )  # rename PC columns: rna_PC{num}
+
+    # read in covariates
+    cov = pd.read_csv(covariate_file_path)
+
+    # Get the index of the column 'geno_PC7'
+    index_of_excluded_geno_pc = cov.columns.get_loc('geno_PC7')
+    # Drop columns from 'geno_PC7' onwards (use the first 6 geno PCs only)
+    cov = cov.iloc[:, :index_of_excluded_geno_pc]
+
+    merged_df = pd.merge(cov, df_pcs, on='sample_id')
+
+    # write to GCP
+    merged_df.to_csv(
+        output_path(f'covariates/{num_pcs}_rna_pcs/{cell_type}_covariates.csv'),
+        index=False,
+    )
+
+
+# inputs:
+@click.option(
+    '--input-dir', help='GCS Path to the input dir storing pseudobulk CSV files'
+)
+@click.option('--cell-types', help='Name of the cell type, comma separated if multiple')
+@click.option(
+    '--chromosomes', help='Chromosome number eg 1, comma separated if multiple'
+)
+@click.option('--job-storage', help='Storage of the batch job eg 30G', default='8G')
+@click.option('--job-memory', help='Memory of the batch job', default='standard')
+@click.option('--job-cpu', help='Number of CPUs of Hail batch job', default=2)
+@click.option('--covariate-file-path', help='GCS Path to the existing covariate file')
+@click.option('--num-pcs', help='Number of PCs to calculate', default=20)
+@click.command()
+def main(
+    input_dir,
+    cell_types,
+    chromosomes,
+    job_storage,
+    job_memory,
+    job_cpu,
+    covariate_file_path,
+    num_pcs,
+):
+    """
+    Obtain cell-type specific covariates for pseudobulk associaTR model
+
+    """
+    b = get_batch()
+
+    logging.info(f'Cell types to run: {cell_types}')
+    logging.info(f'Chromosomes to run: {chromosomes}')
+
+    for cell_type in cell_types.split(','):
+        j = b.new_python_job(
+            name=f'Obtain covariates for for {cell_type}, using chr:{chromosomes}'
+        )
+        j.image('australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3')
+        j.cpu(job_cpu)
+        j.memory(job_memory)
+        j.storage(job_storage)
+        j.call(
+            get_covariates,
+            input_dir,
+            cell_type,
+            chromosomes,
+            covariate_file_path,
+            num_pcs,
+        )
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -27,7 +27,7 @@ def pseudobulk(input_file_path, target_sum):
     Performs pseudobulking in a cell-type chromosome-specific manner
     """
     expression_h5ad_path = to_path(input_file_path).copy('here.h5ad')
-    adata = sc.read_h5ad(expression_h5ad_path, backed = 'r+')
+    adata = sc.read_h5ad(expression_h5ad_path)
 
     # normalisation
     # we can't use pp.normalize_total because the expected input is a chr-specific anndata file, while

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -2,7 +2,6 @@
 """
 This script performs pseudobulk (mean aggregation) of an input AnnData object
 Prior to pseudobulking, the following steps are performed:
-- Remove cells with no counts
 - Normalisation
 - Log transformation (ln(1+x))
 - Batch correction using ComBat
@@ -29,9 +28,6 @@ def pseudobulk(input_file_path, target_sum):
     """
     expression_h5ad_path = to_path(input_file_path).copy('here.h5ad')
     adata = sc.read_h5ad(expression_h5ad_path)
-
-    # remove cells with no counts
-    sc.pp.filter_cells(adata, min_counts=1)
 
     # normalisation
     # we can't use pp.normalize_total because the expected input is a chr-specific anndata file, while

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -2,6 +2,7 @@
 """
 This script performs pseudobulk (mean aggregation) of an input AnnData object
 Prior to pseudobulking, the following steps are performed:
+- Filtering out lowly expressed genes
 - Normalisation
 - Log transformation (ln(1+x))
 - Batch correction

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -4,7 +4,7 @@ This script performs pseudobulk (mean aggregation) of an input AnnData object
 Prior to pseudobulking, the following steps are performed:
 - Normalisation
 - Log transformation (ln(1+x))
-- Batch correction using ComBat
+- Batch correction
 
 Output is a TSV file by cell-type and chromosome-specific. Each row is a sample and each column is a gene.
 
@@ -42,7 +42,7 @@ def pseudobulk(input_file_path, target_sum):
     adata.raw = adata
 
     # batch correction
-    sc.pp.combat(adata, key='sequencing_library')
+    sc.pp.regress_out(adata, keys='sequencing_library')
 
     # initialise array to hold pseudobulk anndata objects
     pbs = []

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -7,38 +7,39 @@ Prior to pseudobulking, the following steps are performed:
 - Log transformation (ln(1+x))
 - Batch correction using ComBat
 
-Output is a TSV file by cell-type. Each row is a sample and each column is a gene.
+Output is a TSV file by cell-type and chromosome-specific. Each row is a sample and each column is a gene.
 
 analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 --description "pseudobulk" --storage=200G --cpu=16 --memory=highmem --output-dir "str/associatr/input_files" pseudobulk.py --input-file=gs://cpg-bioheart-test/str/anndata/test.h5ad
 
 """
 import click
+import logging
 import numpy as np
 import pandas as pd
 import scanpy as sc
 
-from cpg_utils.hail_batch import output_path
+from cpg_utils.hail_batch import get_batch,output_path
 from cpg_utils import to_path
 
 
-# inputs:
-@click.option('--input-file', help='GCS Path to the input AnnData object')
-@click.command()
-def main(input_file):
+def pseudobulk(input_file_path):
     """
-    Perform pseudobulk (mean aggregation) of an input AnnData object
-
-    Args
-        input_file (str): GCS Path to the input AnnData object
+    Performs pseudobulking in a cell-type chromosome-specific manner
     """
-    expression_h5ad_path = to_path(input_file).copy('here.h5ad')
+    expression_h5ad_path = to_path(input_file_path).copy('here.h5ad')
     adata = sc.read_h5ad(expression_h5ad_path)
 
     # remove cells with no counts
     sc.pp.filter_cells(adata, min_counts=1)
 
     # normalisation
-    sc.pp.normalize_total(adata, target_sum=1e6)
+    # we can't use pp.normalize_total because the expected input is a chr-specific anndata file, while
+    # pp.normalize_total expects a whole genome-wide anndata file
+    # obs.total_counts is the sum of counts (genome-wide) for each cell, determined in prior QC processing steps
+    total_counts = adata.obs['total_counts'].values
+    scaled_X = (adata.X / total_counts[:, np.newaxis])*1000000
+    adata.X = scaled_X
+
     # log transformation
     sc.pp.log1p(adata)
     adata.raw = adata
@@ -46,32 +47,64 @@ def main(input_file):
     # batch correction
     sc.pp.combat(adata, key='sequencing_library')
 
-    for cell_type in adata.obs.wg2_scpred_prediction.unique():
-        cell_type_adata = adata[adata.obs['wg2_scpred_prediction'] == cell_type]
-        # each cell type will have its own pseudobulk object
-        pbs = []
-        for chr in cell_type_adata.var.chr.unique():
-            chr_adata = cell_type_adata[:, cell_type_adata.var['chr'] == chr]
-            for sample in chr_adata.obs.individual.unique():
-                samp_cell_subset = adata[adata.obs['individual'] == sample]
-                # pseudobulk mean aggregation
-                rep_adata = sc.AnnData(
-                    X=np.matrix(samp_cell_subset.X.mean(axis=0)),
-                    var=samp_cell_subset.var[[]],
-                )
-                rep_adata.obs_names = [sample]
-                pbs.append(rep_adata)
-        # concatenate individual-specific pseudobulk objects
-        pb = sc.concat(pbs)
+    #initialise array to hold pseudobulk anndata objects
+    pbs = []
 
-        # convert pb into dataframe
-        data_df = pd.DataFrame(pb.X, index=pb.obs.index, columns=pb.var.index)
-        data_df = data_df.rename_axis('individual').reset_index()
-        cell_type_name = cell_type.replace(' ', '_')
-        data_df.to_csv(
-            output_path(f'pseudobulk/{cell_type_name}_pseudobulk.csv'), index=False
+    for sample in adata.obs.individual.unique():
+        samp_cell_subset = adata[adata.obs['individual'] == sample]
+        # pseudobulk mean aggregation
+        rep_adata = sc.AnnData(
+            X=np.matrix(samp_cell_subset.X.mean(axis=0)),
+            var=samp_cell_subset.var[[]],
         )
+        rep_adata.obs_names = [sample]
+        pbs.append(rep_adata)
 
+    # concatenate individual-specific pseudobulk objects
+    pb = sc.concat(pbs)
+
+    # convert pb into dataframe
+    data_df = pd.DataFrame(pb.X, index=pb.obs.index, columns=pb.var.index)
+    data_df = data_df.rename_axis('individual').reset_index()
+
+    cell_type = input_file_path.split('/')[-1].split('_chr')[0]
+    chrom_num = input_file_path.split('/')[-1].split('_chr')[1].split('.')[0]
+
+    data_df.to_csv(
+        output_path(f'pseudobulk/{cell_type}/{cell_type}_chr{chrom_num}_pseudobulk.csv'), index=False
+    )
+
+
+# inputs:
+@click.option('--input-dir', help='GCS Path to the input AnnData object')
+@click.option('--cell-types', help='Name of the cell type, comma separated if multiple')
+@click.option('--chromosomes', help='Chromosome number eg 1, comma separated if multiple')
+@click.option('--job-storage', help='Storage of the batch job eg 30G', default='20G')
+@click.option('--job-memory', help='Memory of the batch job', default='standard')
+@click.option('--job-cpu', help='Number of CPUs of Hail batch job', default=8)
+@click.command()
+def main(input_dir, cell_types, chromosomes, job_storage, job_memory, job_cpu):
+    """
+    Perform pseudobulk (mean aggregation) of an input AnnData object
+
+    """
+    b = get_batch()
+
+    logging.info(f'Cell types to run: {cell_types}')
+    logging.info(f'Chromosomes to run: {chromosomes}')
+
+    for cell_type in cell_types.split(','):
+        for chromosome in chromosomes.split(','):
+            input_file = f'{input_dir}/{cell_type}_chr{chromosome}.h5ad'
+            j = b.new_python_job(
+                name=f'Pseudobulk for cell_type'
+            )
+            j.image('australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3')
+            j.cpu(job_cpu)
+            j.memory(job_memory)
+            j.storage(job_storage)
+            j.call(pseudobulk, input_file)
+    b.run(wait=False)
 
 if __name__ == '__main__':
     main()  # pylint: disable=no-value-for-parameter

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -76,10 +76,7 @@ def pseudobulk(input_file_path, target_sum, min_pct):
     chrom_num = input_file_path.split('/')[-1].split('_chr')[1].split('.')[0]
 
     data_df.to_csv(
-        output_path(
-            f'{cell_type}/{cell_type}_chr{chrom_num}_pseudobulk.csv',
-            'analysis',
-        ),
+        output_path(f'{cell_type}/{cell_type}_chr{chrom_num}_pseudobulk.csv'),
         index=False,
     )
 

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 import scanpy as sc
 
-from cpg_utils.hail_batch import get_batch, output_path,image_path
+from cpg_utils.hail_batch import get_batch, output_path, image_path
 from cpg_utils import to_path
 
 

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -125,7 +125,7 @@ def main(
             j.cpu(job_cpu)
             j.memory(job_memory)
             j.storage(job_storage)
-            j.call(pseudobulk, input_file, target_sum)
+            j.call(pseudobulk, input_file, target_sum, min_pct)
     b.run(wait=False)
 
 

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -98,7 +98,7 @@ def pseudobulk(input_file_path, target_sum, min_pct):
 @click.option(
     '--min-pct',
     help='Minimum percentage of cells expressing a gene to be included in the pseudobulk',
-    default=0.1,
+    default=1,
 )
 @click.command()
 def main(

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -69,7 +69,7 @@ def pseudobulk(input_file_path, target_sum):
 
     data_df.to_csv(
         output_path(
-            f'pseudobulk/{cell_type}/{cell_type}_chr{chrom_num}_pseudobulk.csv',
+            f'{cell_type}/{cell_type}_chr{chrom_num}_pseudobulk.csv',
             'analysis',
         ),
         index=False,

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -17,7 +17,6 @@ import click
 import numpy as np
 import pandas as pd
 import scanpy as sc
-from scipy.sparse import issparse
 
 from cpg_utils.hail_batch import get_batch, output_path
 from cpg_utils import to_path

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -27,7 +27,7 @@ def pseudobulk(input_file_path, target_sum):
     Performs pseudobulking in a cell-type chromosome-specific manner
     """
     expression_h5ad_path = to_path(input_file_path).copy('here.h5ad')
-    adata = sc.read_h5ad(expression_h5ad_path)
+    adata = sc.read_h5ad(expression_h5ad_path, backed = 'r+')
 
     # normalisation
     # we can't use pp.normalize_total because the expected input is a chr-specific anndata file, while

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -70,7 +70,7 @@ def pseudobulk(input_file_path, target_sum):
     data_df.to_csv(
         output_path(
             f'pseudobulk/{cell_type}/{cell_type}_chr{chrom_num}_pseudobulk.csv',
-            'analysis'
+            'analysis',
         ),
         index=False,
     )

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -8,7 +8,7 @@ Prior to pseudobulking, the following steps are performed:
 
 Output is a TSV file by cell-type and chromosome-specific. Each row is a sample and each column is a gene.
 
-analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 --description "pseudobulk" --output-dir "str/associatr/input_files" pseudobulk.py \
+analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images-dev/scanpy_sctransform --description "pseudobulk" --output-dir "str/associatr/input_files" pseudobulk.py \
 --input-dir=gs://cpg-bioheart-test/str/anndata --cell-types=B_naive --chromosomes=10,22
 
 """
@@ -17,9 +17,44 @@ import click
 import numpy as np
 import pandas as pd
 import scanpy as sc
+from scipy.sparse import issparse
 
 from cpg_utils.hail_batch import get_batch, output_path
 from cpg_utils import to_path
+
+def pyScTransform(adata, output_file=None):
+    """
+    Function to call scTransform from Python
+    """
+    import rpy2.robjects as ro
+    import anndata2ri
+
+    ro.r('library(Seurat)')
+    ro.r('library(scater)')
+    anndata2ri.activate()
+
+    sc.pp.filter_genes(adata, min_cells=5)
+
+    if issparse(adata.X):
+        if not adata.X.has_sorted_indices:
+            adata.X.sort_indices()
+
+    for key in adata.layers:
+        if issparse(adata.layers[key]):
+            if not adata.layers[key].has_sorted_indices:
+                adata.layers[key].sort_indices()
+
+    ro.globalenv['adata'] = adata
+
+    ro.r('seurat_obj = as.Seurat(adata, counts="X", data = NULL)')
+
+    ro.r('res <- SCTransform(object=seurat_obj, vars.to.regress = c("pct_counts_mt","batch:),return.only.var.genes = FALSE, do.correct.umi = FALSE)')
+
+    corrected_counts = ro.r('res@assays$SCT@counts').T
+
+    adata.X = corrected_counts
+    if output_file:
+        adata.write(output_file)
 
 
 def pseudobulk(input_file_path, target_sum):

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -69,7 +69,8 @@ def pseudobulk(input_file_path, target_sum):
 
     data_df.to_csv(
         output_path(
-            f'pseudobulk/{cell_type}/{cell_type}_chr{chrom_num}_pseudobulk.csv'
+            f'pseudobulk/{cell_type}/{cell_type}_chr{chrom_num}_pseudobulk.csv',
+            'analysis'
         ),
         index=False,
     )

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -109,7 +109,7 @@ def main(
     for cell_type in cell_types.split(','):
         for chromosome in chromosomes.split(','):
             input_file = f'{input_dir}/{cell_type}_chr{chromosome}.h5ad'
-            j = b.new_python_job(name=f'Pseudobulk for cell_type')
+            j = b.new_python_job(name=f'Pseudobulk for {cell_type}: chr{chromosome}')
             j.image(
                 'australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3'
             )

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 import scanpy as sc
 
-from cpg_utils.hail_batch import get_batch, output_path
+from cpg_utils.hail_batch import get_batch, output_path,image_path
 from cpg_utils import to_path
 
 
@@ -127,9 +127,7 @@ def main(
         for chromosome in chromosomes.split(','):
             input_file = f'{input_dir}/{cell_type}_chr{chromosome}.h5ad'
             j = b.new_python_job(name=f'Pseudobulk for {cell_type}: chr{chromosome}')
-            j.image(
-                'australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3'
-            )
+            j.image(image_path('scanpy'))
             j.cpu(job_cpu)
             j.memory(job_memory)
             j.storage(job_storage)

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -9,7 +9,7 @@ Prior to pseudobulking, the following steps are performed:
 Output is a TSV file by cell-type and chromosome-specific. Each row is a sample and each column is a gene.
 
 analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 --description "pseudobulk" --output-dir "str/associatr/input_files" pseudobulk.py \
---input-dir=gs://cpg-bioheart-test/str/anndata --cell-types=CD4_TCM --chromosomes=1
+--input-dir=gs://cpg-bioheart-test/str/anndata/saige-qtl/anndata_objects_from_HPC --cell-types=CD4_TCM --chromosomes=1 --job-memory=highmem --job-cpu=16
 
 """
 import math
@@ -31,7 +31,7 @@ def pseudobulk(input_file_path, target_sum, min_pct):
     expression_h5ad_path = to_path(input_file_path).copy('here.h5ad')
     adata = sc.read_h5ad(expression_h5ad_path)
 
-    #filter out lowly expressed genes
+    # filter out lowly expressed genes
     n_all_cells = len(adata.obs.index)
     min_cells = math.ceil((n_all_cells * min_pct) / 100)
     sc.pp.filter_genes(adata, min_cells=min_cells)
@@ -89,7 +89,7 @@ def pseudobulk(input_file_path, target_sum, min_pct):
 @click.option(
     '--chromosomes', help='Chromosome number eg 1, comma separated if multiple'
 )
-@click.option('--job-storage', help='Storage of the batch job eg 30G', default='20G')
+@click.option('--job-storage', help='Storage of the batch job eg 30G', default='8G')
 @click.option('--job-memory', help='Memory of the batch job', default='standard')
 @click.option('--job-cpu', help='Number of CPUs of Hail batch job', default=8)
 @click.option(
@@ -104,7 +104,14 @@ def pseudobulk(input_file_path, target_sum, min_pct):
 )
 @click.command()
 def main(
-    input_dir, cell_types, chromosomes, job_storage, job_memory, job_cpu, target_sum, min_pct
+    input_dir,
+    cell_types,
+    chromosomes,
+    job_storage,
+    job_memory,
+    job_cpu,
+    target_sum,
+    min_pct,
 ):
     """
     Perform pseudobulk (mean aggregation) of an input AnnData object

--- a/str/associatr/pseudobulk.py
+++ b/str/associatr/pseudobulk.py
@@ -22,40 +22,6 @@ from scipy.sparse import issparse
 from cpg_utils.hail_batch import get_batch, output_path
 from cpg_utils import to_path
 
-def pyScTransform(adata, output_file=None):
-    """
-    Function to call scTransform from Python
-    """
-    import rpy2.robjects as ro
-    import anndata2ri
-
-    ro.r('library(Seurat)')
-    ro.r('library(scater)')
-    anndata2ri.activate()
-
-    sc.pp.filter_genes(adata, min_cells=5)
-
-    if issparse(adata.X):
-        if not adata.X.has_sorted_indices:
-            adata.X.sort_indices()
-
-    for key in adata.layers:
-        if issparse(adata.layers[key]):
-            if not adata.layers[key].has_sorted_indices:
-                adata.layers[key].sort_indices()
-
-    ro.globalenv['adata'] = adata
-
-    ro.r('seurat_obj = as.Seurat(adata, counts="X", data = NULL)')
-
-    ro.r('res <- SCTransform(object=seurat_obj, vars.to.regress = c("pct_counts_mt","batch:),return.only.var.genes = FALSE, do.correct.umi = FALSE)')
-
-    corrected_counts = ro.r('res@assays$SCT@counts').T
-
-    adata.X = corrected_counts
-    if output_file:
-        adata.write(output_file)
-
 
 def pseudobulk(input_file_path, target_sum):
     """


### PR DESCRIPTION
Changing design of the script so that instead of requiring an Anndata object with the whole genome for all cells (OOM error: https://batch.hail.populationgenomics.org.au/batches/434085/jobs/1), it parses smaller Anndata objects that are subsetted to one chromosome, one cell type. 

This change requires me to DIY the `normalize_total()` method because scanpy's implementation will re-calculate the total counts (representing the number of transcript counts across the whole genome for that particular cell) across the Anndata object. This is incorrect because the Anndata object will not have all the genes anymore (input objects are expected to be restricted to one chromosome). FORTUNATELY, `calculate_qc_metrics()` was run on the giant AnnData object (with all cells, all chromosomes) in an upstream step - storing the true `total_counts` as a row attribute in `obs` (https://github.com/powellgenomicslab/tenk10k_phase1/blob/main/Scanpy/add_metadata_per_sample_no_norm.py#L131), so we can use this attribute during DIY normalization. 

Successful batch: https://batch.hail.populationgenomics.org.au/batches/434123 - please ignore the non-descriptive job name (updated in the most recent commit!)

Still OOM with really large chr1 AnnData objects (rest were successful): https://batch.hail.populationgenomics.org.au/batches/434253/jobs/45 - how do we reduce RAM usage further? 
Tried `backed` mode for the `read_h5ad()` but threw a processing error - I think it has limitations on what processing can be done on backed mode. 

