### PR TITLE
Create get_covariates.py for associaTR pseudobulk pipeline

### DIFF
--- a/str/associatr/get_cis_numpy_files.py
+++ b/str/associatr/get_cis_numpy_files.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# pylint: disable=too-many-arguments,too-many-locals
+
+"""
+This script aims to:
+ - output gene lists for each cell type and chromosome (after filtering out lowly expressed genes)
+ - output cis window files for each gene with scRNA data (cell type + chr specific)
+ - optionally removes samples based on a provided sample file
+ - perform rank-based inverse normal transformation on pseudobulk data (per gene basis)
+ - output gene-level phenotype and covariate numpy objects for input into associatr
+
+ analysis-runner  --config get_cis_numpy_files.toml --dataset "bioheart" --access-level "test" \
+--description "get cis and numpy" --output-dir "str/associatr/rna_pc_calibration/2_pcs/input_files"  \
+--image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
+python3 get_cis_numpy_files.py
+
+"""
+import json
+from ast import literal_eval
+
+import numpy as np
+import pandas as pd
+import scanpy as sc
+import hail as hl
+import hailtop.batch as hb
+from scipy.stats import norm
+
+
+from cpg_utils.hail_batch import get_batch, output_path, init_batch, image_path
+from cpg_utils.config import get_config
+from cpg_utils import to_path
+
+
+def cis_window_numpy_extractor(
+    input_h5ad_dir,
+    input_pseudobulk_dir,
+    input_cov_dir,
+    chromosome,
+    cell_type,
+    cis_window,
+    version,
+    chrom_len,
+    min_pct,
+    remove_samples_file,
+):
+    """
+    Creates gene-specific cis window files and phenotype-covariate numpy objects
+
+    """
+    init_batch()
+
+    # read in anndata object because anndata.vars has the start, end coordinates of each gene
+    h5ad_file_path = f'{input_h5ad_dir}/{cell_type}_{chromosome}.h5ad'
+    expression_h5ad_path = to_path(h5ad_file_path).copy('here.h5ad')
+    adata = sc.read_h5ad(expression_h5ad_path)
+
+    # read in pseudobulk and covariate files
+    pseudobulk_path = (
+        f'{input_pseudobulk_dir}/{cell_type}/{cell_type}_{chromosome}_pseudobulk.csv'
+    )
+    pseudobulk = pd.read_csv(pseudobulk_path)
+    covariate_path = f'{input_cov_dir}/{cell_type}_covariates.csv'
+    covariates = pd.read_csv(covariate_path)
+
+    # extract genes in pseudobulk df
+    gene_names = list(pseudobulk.columns[1:])  # individual ID is the first column
+
+    # write filtered gene names to a JSON file
+    with to_path(
+        output_path(
+            f'scRNA_gene_lists/{min_pct}_min_pct_cells_expressed/{cell_type}/{chromosome}_{cell_type}_gene_list.json'
+        )
+    ).open('w') as write_handle:
+        json.dump(gene_names, write_handle)
+
+    for gene in gene_names:
+        # get gene body position (start and end) and add window
+        start_coord = adata.var[adata.var.index == gene]['start']
+        end_coord = adata.var[adata.var.index == gene]['end']
+
+        left_boundary = max(1, int(start_coord.iloc[0]) - int(cis_window))
+        right_boundary = min(int(end_coord.iloc[0]) + int(cis_window), chrom_len)
+
+        data = {'chromosome': chromosome, 'start': left_boundary, 'end': right_boundary}
+        ofile_path = output_path(
+            f'cis_window_files/{version}/{cell_type}/{chromosome}/{gene}_{cis_window}bp.bed'
+        )
+        # write cis window file to gcp
+        pd.DataFrame(data, index=[gene]).to_csv(
+            ofile_path, sep='\t', header=False, index=False
+        )
+
+        # make the phenotype-covariate numpy objects
+        pseudobulk.rename(columns={'individual': 'sample_id'}, inplace=True)
+        gene_pheno = pseudobulk[['sample_id', gene]]
+
+        # remove samples that are in the remove_samples_file
+        if remove_samples_file:
+            with to_path(remove_samples_file).open() as f:
+                array_string = f.read().strip()
+                remove_samples = literal_eval(array_string)
+                gene_pheno = gene_pheno[~gene_pheno['sample_id'].isin(remove_samples)]
+
+        # rank-based inverse normal transformation based on R's orderNorm()
+        # Rank the values
+        gene_pheno.loc[:, 'gene_rank'] = gene_pheno[gene].rank()
+        # Calculate the percentile of each rank
+        gene_pheno.loc[:, 'gene_percentile'] = (
+            gene_pheno.loc[:, 'gene_rank'] - 0.5
+        ) / (len(gene_pheno))
+        # Use the inverse normal cumulative distribution function (quantile function) to transform percentiles to normal distribution values
+        gene_pheno.loc[:, 'gene_inverse_normal'] = norm.ppf(
+            gene_pheno.loc[:, 'gene_percentile']
+        )
+        gene_pheno = gene_pheno[['sample_id', 'gene_inverse_normal']]
+
+        gene_pheno_cov = gene_pheno.merge(covariates, on='sample_id', how='inner')
+
+        # filter for samples that were assigned a CPG ID; unassigned samples after demultiplexing will not have a CPG ID
+        gene_pheno_cov = gene_pheno_cov[
+            gene_pheno_cov['sample_id'].str.startswith('CPG')
+        ]
+
+        # add in cohort as a covariate
+        cohort_cpg_id = adata.obs[['cpg_id', 'cohort']]
+        mapping = {'TOB': 1, 'BioHEART': 2}
+        cohort_cpg_id['cohort'] = cohort_cpg_id['cohort'].map(mapping)
+        cohort_cpg_id.rename(columns={'cpg_id': 'sample_id'}, inplace=True)
+        cohort_cpg_id = cohort_cpg_id.drop_duplicates()
+
+        gene_pheno_cov = gene_pheno_cov.merge(
+            cohort_cpg_id, on='sample_id', how='inner'
+        )
+
+        gene_pheno_cov['sample_id'] = gene_pheno_cov['sample_id'].str[
+            3:
+        ]  # remove CPG prefix because associatr expects id to be numeric
+
+        gene_pheno_cov['sample_id'] = gene_pheno_cov['sample_id'].astype(float)
+
+        gene_pheno_cov = gene_pheno_cov.to_numpy()
+        with hl.hadoop_open(
+            output_path(
+                f'pheno_cov_numpy/{version}/{cell_type}/{chromosome}/{gene}_pheno_cov.npy'
+            ),
+            'wb',
+        ) as f:
+            np.save(f, gene_pheno_cov)
+
+
+def main():
+    """
+    Run cis window extraction and phenotype/covariate numpy object creation
+    """
+    b = get_batch(name='get cis_numpy files')
+
+    # Setup MAX concurrency by genes
+    _dependent_jobs: list[hb.batch.job.Job] = []
+
+    def manage_concurrency_for_job(job: hb.batch.job.Job):
+        """
+        To avoid having too many jobs running at once, we have to limit concurrency.
+        """
+        if len(_dependent_jobs) >= get_config()['get_cis_numpy']['max_parallel_jobs']:
+            job.depends_on(
+                _dependent_jobs[-get_config()['get_cis_numpy']['max_parallel_jobs']]
+            )
+        _dependent_jobs.append(job)
+
+    for cell_type in get_config()['get_cis_numpy']['cell_types'].split(','):
+        for chrom in get_config()['get_cis_numpy']['chromosomes'].split(','):
+            init_batch()
+            chrom_len = hl.get_reference('GRCh38').lengths[chrom]
+            j = b.new_python_job(
+                name=f'Extract cis window & phenotype and covariate numpy object for {cell_type}: {chrom}'
+            )
+            j.image(image_path('scanpy'))
+            j.cpu(get_config()['get_cis_numpy']['job_cpu'])
+            j.memory(get_config()['get_cis_numpy']['job_memory'])
+            j.storage(get_config()['get_cis_numpy']['job_storage'])
+            j.call(
+                cis_window_numpy_extractor,
+                get_config()['get_cis_numpy']['input_h5ad_dir'],
+                get_config()['get_cis_numpy']['input_pseudobulk_dir'],
+                get_config()['get_cis_numpy']['input_cov_dir'],
+                chrom,
+                cell_type,
+                get_config()['get_cis_numpy']['cis_window'],
+                get_config()['get_cis_numpy']['version'],
+                chrom_len,
+                get_config()['get_cis_numpy']['min_pct'],
+                get_config()['get_cis_numpy']['remove_samples_file'],
+            )
+
+            manage_concurrency_for_job(j)
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter,too-many-arguments

--- a/str/associatr/get_cis_numpy_files.toml
+++ b/str/associatr/get_cis_numpy_files.toml
@@ -1,0 +1,21 @@
+[get_cis_numpy]
+# GCS directory to the input AnnData objects
+input_h5ad_dir = 'gs://cpg-bioheart-test/str/anndata-240/cpg_anndata/cpg_anndata'
+# GCS directory to the input pseudobulk CSV files
+input_pseudobulk_dir = 'gs://cpg-bioheart-test/str/associatr/input_files/pseudobulk'
+# GCS directory to the input covariate CSV files
+input_cov_dir = 'gs://cpg-bioheart-test/str/associatr/rna_pc_calibration/5_pcs/input_files/covariates/5_rna_pcs'
+chromosomes = 'chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22'
+cell_types = 'CD8_TEM'
+# cis window size in bp
+cis_window = 100000
+version = 'v1'
+job_cpu = 1
+job_memory = 'standard'
+job_storage = '0G'
+# To avoid exceeding Google Cloud quotas, set a concurrency as a limit.
+max_parallel_jobs = 500
+# filter out genes that are expressed in fewer than XX% of cells
+min_pct = 1
+# GCS path to the file containing the list of samples to remove
+remove_samples_file = 'gs://cpg-bioheart-test/str/associatr/input_files/remove-samples.txt'

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -57,7 +57,7 @@ def get_covariates(
 
     # Variance ratio plot
     sc.pl.pca_variance_ratio(adata_genome, save='local.png')
-    hl.hadoop_copy('figures/pca_variance_ratiolocal.png', output_path(f'{cell_type}_scree_plot.png', 'analysis'))
+    hl.hadoop_copy('figures/pca_variance_ratiolocal.png', output_path(f'pseudobulk_RNA_PCs_scree_plots/{cell_type}_scree_plot.png', 'analysis'))
 
     # extract PCs
     df_pcs = pd.DataFrame(adata_genome.obsm['X_pca'])

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -71,7 +71,7 @@ def get_covariates(
     ).reset_index()  # index (CPG ids) are not stored in 'sample_id' column
     df_pcs = df_pcs[
         ['sample_id'] + list(range(num_pcs))
-    ]  # only keep first 20 PCs by default
+    ]
     df_pcs = df_pcs.rename(
         columns={i: f'rna_PC{i+1}' for i in range(num_pcs)}
     )  # rename PC columns: rna_PC{num}

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -13,8 +13,9 @@ import logging
 import click
 import pandas as pd
 import scanpy as sc
+import hail as hl
 
-from cpg_utils.hail_batch import get_batch, output_path
+from cpg_utils.hail_batch import output_path, init_batch, get_batch
 from cpg_utils import to_path
 
 
@@ -24,12 +25,12 @@ def get_covariates(
     chromosomes,
     covariate_file_path,
     num_pcs,
-    ofile_path,
 ):
     """
     Calculates cell-type specific PCs from the pseudobulk data (genome-wide),
     merges them with other pre-calculated covariates, and writes file to GCP
     """
+    init_batch()
 
     # read in and concatenate pseudobulk data (chr-specific --> genome-wide anndata)
     adatas = []
@@ -55,7 +56,8 @@ def get_covariates(
     sc.tl.pca(adata_genome, svd_solver='arpack')
 
     # Variance ratio plot
-    sc.pl.pca_variance_ratio(adata_genome, save=str(ofile_path))
+    sc.pl.pca_variance_ratio(adata_genome, save='local_scree_plot.png')
+    hl.hadoop_copy('local_scree_plot.png', output_path(f'{cell_type}_scree_plot.png', 'analysis'))
 
     # extract PCs
     df_pcs = pd.DataFrame(adata_genome.obsm['X_pca'])
@@ -63,7 +65,7 @@ def get_covariates(
     df_pcs = df_pcs.rename_axis(
         'sample_id'
     ).reset_index()  # index (CPG ids) are not stored in 'sample_id' column
-    df_pcs = df_pcs[['sample_id'] + list(range(num_pcs))]  # only keep first 20 PCs
+    df_pcs = df_pcs[['sample_id'] + list(range(num_pcs))]  # only keep first 20 PCs by default
     df_pcs = df_pcs.rename(
         columns={i: f'rna_PC{i+1}' for i in range(num_pcs)}
     )  # rename PC columns: rna_PC{num}
@@ -127,15 +129,8 @@ def main(
             chromosomes,
             covariate_file_path,
             num_pcs,
-            j.ofile,
         )
-        j.ofile.add_extension('.png')
-        b.write_output(
-            j.ofile,
-            output_path(
-                f'covariates/scree_plots/{cell_type}_scree_plot.png', 'analysis'
-            ),
-        )
+
 
     b.run(wait=False)
 

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -4,7 +4,7 @@ This script calculates cell-type specific PCs from the pseudobulk RNA data (geno
 merges them with other pre-calculated covariates, and writes the file to GCP.
 
 analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
---description "Get covariates" --output-dir "str/associatr/input_files/rna_pc_calibration/2_pcs" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/input_files/pseudobulk \
+--description "Get covariates" --output-dir "str/associatr/rna_pc_calibration/2_pcs/input_files" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/input_files/pseudobulk/pseudobulk \
 --cell-types=CD8_TEM --chromosomes=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 --covariate-file-path=gs://cpg-bioheart-test/str/anndata/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv \
 --num-pcs=2
 

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -5,7 +5,7 @@ merges them with other pre-calculated covariates, and writes the file to GCP.
 
 analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
 --description "Get covariates" --output-dir "str/associatr/input_files" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/input_files/pseudobulk \
---cell-types=B_naive --chromosomes=10,22 --covariate-file-path=gs://cpg-bioheart-test/str/anndata/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv
+--cell-types=ASDC --chromosomes=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 --covariate-file-path=gs://cpg-bioheart-test/str/anndata/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv
 
 """
 
@@ -18,7 +18,14 @@ from cpg_utils.hail_batch import get_batch, output_path
 from cpg_utils import to_path
 
 
-def get_covariates(pseudobulk_input_dir, cell_type, chromosomes, covariate_file_path):
+def get_covariates(
+    pseudobulk_input_dir,
+    cell_type,
+    chromosomes,
+    covariate_file_path,
+    num_pcs,
+    ofile_path,
+):
     """
     Calculates cell-type specific PCs from the pseudobulk data (genome-wide),
     merges them with other pre-calculated covariates, and writes file to GCP
@@ -47,15 +54,18 @@ def get_covariates(pseudobulk_input_dir, cell_type, chromosomes, covariate_file_
     # PCA
     sc.tl.pca(adata_genome, svd_solver='arpack')
 
+    # Variance ratio plot
+    sc.pl.pca_variance_ratio(adata_genome, save=str(ofile_path))
+
     # extract PCs
     df_pcs = pd.DataFrame(adata_genome.obsm['X_pca'])
     df_pcs.index = adata_genome.obs.index
     df_pcs = df_pcs.rename_axis(
         'sample_id'
     ).reset_index()  # index (CPG ids) are not stored in 'sample_id' column
-    df_pcs = df_pcs[['sample_id'] + list(range(20))]  # only keep first 20 PCs
+    df_pcs = df_pcs[['sample_id'] + list(range(num_pcs))]  # only keep first 20 PCs
     df_pcs = df_pcs.rename(
-        columns={i: f'rna_PC{i+1}' for i in range(20)}
+        columns={i: f'rna_PC{i+1}' for i in range(num_pcs)}
     )  # rename PC columns: rna_PC{num}
 
     # read in covariates
@@ -81,6 +91,7 @@ def get_covariates(pseudobulk_input_dir, cell_type, chromosomes, covariate_file_
 @click.option('--job-memory', help='Memory of the batch job', default='standard')
 @click.option('--job-cpu', help='Number of CPUs of Hail batch job', default=8)
 @click.option('--covariate-file-path', help='GCS Path to the existing covariate file')
+@click.option('--num-pcs', help='Number of PCs to calculate', default=20)
 @click.command()
 def main(
     input_dir,
@@ -90,6 +101,7 @@ def main(
     job_memory,
     job_cpu,
     covariate_file_path,
+    num_pcs,
 ):
     """
     Obtain cell-type specific covariates for pseudobulk associaTR model
@@ -108,7 +120,22 @@ def main(
         j.cpu(job_cpu)
         j.memory(job_memory)
         j.storage(job_storage)
-        j.call(get_covariates, input_dir, cell_type, chromosomes, covariate_file_path)
+        j.call(
+            get_covariates,
+            input_dir,
+            cell_type,
+            chromosomes,
+            covariate_file_path,
+            num_pcs,
+            j.ofile,
+        )
+        j.ofile.add_extension('.png')
+        b.write_output(
+            j.ofile,
+            output_path(
+                f'covariates/scree_plots/{cell_type}_scree_plot.png', 'analysis'
+            ),
+        )
 
     b.run(wait=False)
 

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -80,6 +80,12 @@ def get_covariates(
     # read in covariates
     cov = pd.read_csv(covariate_file_path)
 
+    # Get the index of the column 'geno_PC7'
+    index_of_geno_PC7 = cov.columns.get_loc('geno_PC7')
+    # Drop columns from 'geno_PC7' onwards (use the first 6 geno PCs only)
+    cov = cov.iloc[:, :index_of_geno_PC7]
+
+
     merged_df = pd.merge(cov, df_pcs, on='sample_id')
 
     # write to GCP

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -108,7 +108,6 @@ def main(
         j.cpu(job_cpu)
         j.memory(job_memory)
         j.storage(job_storage)
-        print('starting job')
         j.call(get_covariates, input_dir, cell_type, chromosomes, covariate_file_path)
 
     b.run(wait=False)

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -69,9 +69,7 @@ def get_covariates(
     df_pcs = df_pcs.rename_axis(
         'sample_id'
     ).reset_index()  # index (CPG ids) are not stored in 'sample_id' column
-    df_pcs = df_pcs[
-        ['sample_id'] + list(range(num_pcs))
-    ]
+    df_pcs = df_pcs[['sample_id'] + list(range(num_pcs))]
     df_pcs = df_pcs.rename(
         columns={i: f'rna_PC{i+1}' for i in range(num_pcs)}
     )  # rename PC columns: rna_PC{num}

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -80,9 +80,9 @@ def get_covariates(
     cov = pd.read_csv(covariate_file_path)
 
     # Get the index of the column 'geno_PC7'
-    index_of_geno_PC7 = cov.columns.get_loc('geno_PC7')
+    index_of_excluded_geno_pc = cov.columns.get_loc('geno_PC7')
     # Drop columns from 'geno_PC7' onwards (use the first 6 geno PCs only)
-    cov = cov.iloc[:, :index_of_geno_PC7]
+    cov = cov.iloc[:, :index_of_excluded_geno_pc]
 
     merged_df = pd.merge(cov, df_pcs, on='sample_id')
 

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -57,7 +57,12 @@ def get_covariates(
 
     # Variance ratio plot
     sc.pl.pca_variance_ratio(adata_genome, save='local.png')
-    hl.hadoop_copy('figures/pca_variance_ratiolocal.png', output_path(f'pseudobulk_RNA_PCs_scree_plots/{cell_type}_scree_plot.png', 'analysis'))
+    hl.hadoop_copy(
+        'figures/pca_variance_ratiolocal.png',
+        output_path(
+            f'pseudobulk_RNA_PCs_scree_plots/{cell_type}_scree_plot.png', 'analysis'
+        ),
+    )
 
     # extract PCs
     df_pcs = pd.DataFrame(adata_genome.obsm['X_pca'])
@@ -65,7 +70,9 @@ def get_covariates(
     df_pcs = df_pcs.rename_axis(
         'sample_id'
     ).reset_index()  # index (CPG ids) are not stored in 'sample_id' column
-    df_pcs = df_pcs[['sample_id'] + list(range(num_pcs))]  # only keep first 20 PCs by default
+    df_pcs = df_pcs[
+        ['sample_id'] + list(range(num_pcs))
+    ]  # only keep first 20 PCs by default
     df_pcs = df_pcs.rename(
         columns={i: f'rna_PC{i+1}' for i in range(num_pcs)}
     )  # rename PC columns: rna_PC{num}
@@ -77,7 +84,10 @@ def get_covariates(
 
     # write to GCP
     merged_df.to_csv(
-        output_path(f'covariates/{cell_type}_covariates.csv', 'analysis'), index=False
+        output_path(
+            f'covariates/{num_pcs}_rna_pcs/{cell_type}_covariates.csv', 'analysis'
+        ),
+        index=False,
     )
 
 
@@ -130,7 +140,6 @@ def main(
             covariate_file_path,
             num_pcs,
         )
-
 
     b.run(wait=False)
 

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -4,7 +4,7 @@ This script calculates cell-type specific PCs from the pseudobulk RNA data (geno
 merges them with other pre-calculated covariates, and writes the file to GCP.
 
 analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
---description "Get covariates" --output-dir "str/associatr/input_files" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/pseudobulk \
+--description "Get covariates" --output-dir "str/associatr/input_files" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/input_files/pseudobulk \
 --cell-types=B_naive --chromosomes=10,22 --covariate-file-path=gs://cpg-bioheart-test/str/anndata/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv
 
 """

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -27,7 +27,9 @@ def get_covariates(pseudobulk_input_dir, cell_type, chromosomes, covariate_file_
     # read in and concatenate pseudobulk data (chr-specific --> genome-wide anndata)
     adatas = []
     for i in chromosomes.split(','):
-        gcs_file_path = f'{pseudobulk_input_dir}/{cell_type}/{cell_type}_chr{i}_pseudobulk.csv'
+        gcs_file_path = (
+            f'{pseudobulk_input_dir}/{cell_type}/{cell_type}_chr{i}_pseudobulk.csv'
+        )
 
         local_file_path = to_path(gcs_file_path).copy('here.csv')
         adata = sc.read_csv(local_file_path)
@@ -61,7 +63,7 @@ def get_covariates(pseudobulk_input_dir, cell_type, chromosomes, covariate_file_
     merged_df = pd.merge(cov, df_pcs, on='sample_id')
 
     # write to GCP
-    merged_df.to_csv(output_path(f'covariates/{cell_type}_covariates.csv'), index=False)
+    merged_df.to_csv(output_path(f'covariates/{cell_type}_covariates.csv', 'analysis'), index=False)
 
 
 # inputs:

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -3,31 +3,37 @@
 This script calculates cell-type specific PCs from the pseudobulk RNA data (genome-wide),
 merges them with other pre-calculated covariates, and writes the file to GCP.
 
+analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
+--description "Get covariates" --output-dir "str/associatr/input_files" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/pseudobulk \
+--cell-types=B_naive --chromosomes=10,22 --covariate-file-path=gs://cpg-bioheart-test/str/anndata/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv
+
 """
 
 import logging
 import click
-import numpy as np
 import pandas as pd
 import scanpy as sc
 
 from cpg_utils.hail_batch import get_batch, output_path
 from cpg_utils import to_path
 
-def get_covariates(pseudobulk_input_dir,cell_type,chromosomes, covariate_file_path):
+
+def get_covariates(pseudobulk_input_dir, cell_type, chromosomes, covariate_file_path):
     """
     Calculates cell-type specific PCs from the pseudobulk data (genome-wide),
     merges them with other pre-calculated covariates, and writes file to GCP
     """
 
     # read in and concatenate pseudobulk data (chr-specific --> genome-wide anndata)
-    adatas =[]
+    adatas = []
     for i in chromosomes.split(','):
-        gcs_file_path = f"{pseudobulk_input_dir}/{cell_type}/{cell_type}_chr{i}_pseudobulk.csv"
+        gcs_file_path = (
+            f'{pseudobulk_input_dir}/{cell_type}/{cell_type}_chr{i}_pseudobulk.csv'
+        )
         local_file_path = to_path(gcs_file_path).copy('here.csv')
         adata = sc.read_csv(local_file_path)
         adatas.append(adata)
-    adata_genome = sc.concat(adatas,axis =1)
+    adata_genome = sc.concat(adatas, axis=1)
 
     # subset to high variance genes prior to PCA
     sc.pp.highly_variable_genes(adata_genome, min_mean=0.0125, max_mean=3, min_disp=0.5)
@@ -42,9 +48,13 @@ def get_covariates(pseudobulk_input_dir,cell_type,chromosomes, covariate_file_pa
     # extract PCs
     df_pcs = pd.DataFrame(adata_genome.obsm['X_pca'])
     df_pcs.index = adata_genome.obs.index
-    df_pcs = df_pcs.rename_axis('sample_id').reset_index() # index (CPG ids) are not stored in 'sample_id' column
-    df_pcs = df_pcs[['sample_id'] + list(range(20))] # only keep first 20 PCs
-    df_pcs = df_pcs.rename(columns={i: f'rna_PC{i+1}' for i in range(20)}) # rename PC columns: rna_PC{num}
+    df_pcs = df_pcs.rename_axis(
+        'sample_id'
+    ).reset_index()  # index (CPG ids) are not stored in 'sample_id' column
+    df_pcs = df_pcs[['sample_id'] + list(range(20))]  # only keep first 20 PCs
+    df_pcs = df_pcs.rename(
+        columns={i: f'rna_PC{i+1}' for i in range(20)}
+    )  # rename PC columns: rna_PC{num}
 
     # read in covariates
     cov = pd.read_csv(covariate_file_path)
@@ -54,8 +64,11 @@ def get_covariates(pseudobulk_input_dir,cell_type,chromosomes, covariate_file_pa
     # write to GCP
     merged_df.to_csv(output_path(f'covariates/{cell_type}_covariates.csv'), index=False)
 
+
 # inputs:
-@click.option('--input-dir', help='GCS Path to the input dir storing pseudobulk CSV files')
+@click.option(
+    '--input-dir', help='GCS Path to the input dir storing pseudobulk CSV files'
+)
 @click.option('--cell-types', help='Name of the cell type, comma separated if multiple')
 @click.option(
     '--chromosomes', help='Chromosome number eg 1, comma separated if multiple'
@@ -66,7 +79,13 @@ def get_covariates(pseudobulk_input_dir,cell_type,chromosomes, covariate_file_pa
 @click.option('--covariate-file-path', help='GCS Path to the existing covariate file')
 @click.command()
 def main(
-    input_dir, cell_types, chromosomes, job_storage, job_memory, job_cpu, covariate_file_path
+    input_dir,
+    cell_types,
+    chromosomes,
+    job_storage,
+    job_memory,
+    job_cpu,
+    covariate_file_path,
 ):
     """
     Obtain cell-type specific covariattes for pseudobulk associaTR model
@@ -78,10 +97,10 @@ def main(
     logging.info(f'Chromosomes to run: {chromosomes}')
 
     for cell_type in cell_types.split(','):
-        j = b.new_python_job(name=f'Obtain covariates for for {cell_type}, using chr:{chromosomes}')
-        j.image(
-            'australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3'
+        j = b.new_python_job(
+            name=f'Obtain covariates for for {cell_type}, using chr:{chromosomes}'
         )
+        j.image('australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3')
         j.cpu(job_cpu)
         j.memory(job_memory)
         j.storage(job_storage)
@@ -92,10 +111,3 @@ def main(
 
 if __name__ == '__main__':
     main()  # pylint: disable=no-value-for-parameter
-
-
-
-
-
-
-

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+This script calculates cell-type specific PCs from the pseudobulk RNA data (genome-wide),
+merges them with other pre-calculated covariates, and writes the file to GCP.
+
+"""
+
+import logging
+import click
+import numpy as np
+import pandas as pd
+import scanpy as sc
+
+from cpg_utils.hail_batch import get_batch, output_path
+from cpg_utils import to_path
+
+def get_covariates(pseudobulk_input_dir,cell_type,chromosomes, covariate_file_path):
+    """
+    Calculates cell-type specific PCs from the pseudobulk data (genome-wide),
+    merges them with other pre-calculated covariates, and writes file to GCP
+    """
+
+    # read in and concatenate pseudobulk data (chr-specific --> genome-wide anndata)
+    adatas =[]
+    for i in chromosomes.split(','):
+        gcs_file_path = f"{pseudobulk_input_dir}/{cell_type}/{cell_type}_chr{i}_pseudobulk.csv"
+        local_file_path = to_path(gcs_file_path).copy('here.csv')
+        adata = sc.read_csv(local_file_path)
+        adatas.append(adata)
+    adata_genome = sc.concat(adatas,axis =1)
+
+    # subset to high variance genes prior to PCA
+    sc.pp.highly_variable_genes(adata_genome, min_mean=0.0125, max_mean=3, min_disp=0.5)
+    adata_genome = adata_genome[:, adata_genome.var.highly_variable]
+
+    # unit variance scaling for PCA
+    sc.pp.scale(adata_genome, max_value=10)
+
+    # PCA
+    sc.tl.pca(adata_genome, svd_solver='arpack')
+
+    # extract PCs
+    df_pcs = pd.DataFrame(adata_genome.obsm['X_pca'])
+    df_pcs.index = adata_genome.obs.index
+    df_pcs = df_pcs.rename_axis('sample_id').reset_index() # index (CPG ids) are not stored in 'sample_id' column
+    df_pcs = df_pcs[['sample_id'] + list(range(20))] # only keep first 20 PCs
+    df_pcs = df_pcs.rename(columns={i: f'rna_PC{i+1}' for i in range(20)}) # rename PC columns: rna_PC{num}
+
+    # read in covariates
+    cov = pd.read_csv(covariate_file_path)
+
+    merged_df = pd.merge(cov, df_pcs, on='sample_id')
+
+    # write to GCP
+    merged_df.to_csv(output_path(f'covariates/{cell_type}_covariates.csv'), index=False)
+
+# inputs:
+@click.option('--input-dir', help='GCS Path to the input dir storing pseudobulk CSV files')
+@click.option('--cell-types', help='Name of the cell type, comma separated if multiple')
+@click.option(
+    '--chromosomes', help='Chromosome number eg 1, comma separated if multiple'
+)
+@click.option('--job-storage', help='Storage of the batch job eg 30G', default='20G')
+@click.option('--job-memory', help='Memory of the batch job', default='standard')
+@click.option('--job-cpu', help='Number of CPUs of Hail batch job', default=8)
+@click.option('--covariate-file-path', help='GCS Path to the existing covariate file')
+@click.command()
+def main(
+    input_dir, cell_types, chromosomes, job_storage, job_memory, job_cpu, covariate_file_path
+):
+    """
+    Obtain cell-type specific covariattes for pseudobulk associaTR model
+
+    """
+    b = get_batch()
+
+    logging.info(f'Cell types to run: {cell_types}')
+    logging.info(f'Chromosomes to run: {chromosomes}')
+
+    for cell_type in cell_types.split(','):
+        j = b.new_python_job(name=f'Obtain covariates for for {cell_type}, using chr:{chromosomes}')
+        j.image(
+            'australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3'
+        )
+        j.cpu(job_cpu)
+        j.memory(job_memory)
+        j.storage(job_storage)
+        j.call(get_covariates, input_dir, cell_type, chromosomes, covariate_file_path)
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter
+
+
+
+
+
+
+

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -56,8 +56,8 @@ def get_covariates(
     sc.tl.pca(adata_genome, svd_solver='arpack')
 
     # Variance ratio plot
-    sc.pl.pca_variance_ratio(adata_genome, save='local_scree_plot.png')
-    hl.hadoop_copy('local_scree_plot.png', output_path(f'{cell_type}_scree_plot.png', 'analysis'))
+    sc.pl.pca_variance_ratio(adata_genome, save='local.png')
+    hl.hadoop_copy('figures/pca_variance_ratiolocal.png', output_path(f'{cell_type}_scree_plot.png', 'analysis'))
 
     # extract PCs
     df_pcs = pd.DataFrame(adata_genome.obsm['X_pca'])

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -30,7 +30,7 @@ def get_covariates(pseudobulk_input_dir, cell_type, chromosomes, covariate_file_
         gcs_file_path = (
             f'{pseudobulk_input_dir}/{cell_type}/{cell_type}_chr{i}_pseudobulk.csv'
         )
-        logging.info(f'Loading {gcs_file_path}...')
+        print(f'Loading {gcs_file_path}...')
 
         local_file_path = to_path(gcs_file_path).copy('here.csv')
         adata = sc.read_csv(local_file_path)
@@ -108,6 +108,7 @@ def main(
         j.cpu(job_cpu)
         j.memory(job_memory)
         j.storage(job_storage)
+        print('starting job')
         j.call(get_covariates, input_dir, cell_type, chromosomes, covariate_file_path)
 
     b.run(wait=False)

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -63,7 +63,9 @@ def get_covariates(pseudobulk_input_dir, cell_type, chromosomes, covariate_file_
     merged_df = pd.merge(cov, df_pcs, on='sample_id')
 
     # write to GCP
-    merged_df.to_csv(output_path(f'covariates/{cell_type}_covariates.csv', 'analysis'), index=False)
+    merged_df.to_csv(
+        output_path(f'covariates/{cell_type}_covariates.csv', 'analysis'), index=False
+    )
 
 
 # inputs:

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -87,9 +87,9 @@ def get_covariates(
 @click.option(
     '--chromosomes', help='Chromosome number eg 1, comma separated if multiple'
 )
-@click.option('--job-storage', help='Storage of the batch job eg 30G', default='20G')
+@click.option('--job-storage', help='Storage of the batch job eg 30G', default='8G')
 @click.option('--job-memory', help='Memory of the batch job', default='standard')
-@click.option('--job-cpu', help='Number of CPUs of Hail batch job', default=8)
+@click.option('--job-cpu', help='Number of CPUs of Hail batch job', default=2)
 @click.option('--covariate-file-path', help='GCS Path to the existing covariate file')
 @click.option('--num-pcs', help='Number of PCs to calculate', default=20)
 @click.command()

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -30,6 +30,7 @@ def get_covariates(pseudobulk_input_dir, cell_type, chromosomes, covariate_file_
         gcs_file_path = (
             f'{pseudobulk_input_dir}/{cell_type}/{cell_type}_chr{i}_pseudobulk.csv'
         )
+        logging.info(f'Loading {gcs_file_path}...')
 
         local_file_path = to_path(gcs_file_path).copy('here.csv')
         adata = sc.read_csv(local_file_path)
@@ -91,7 +92,7 @@ def main(
     covariate_file_path,
 ):
     """
-    Obtain cell-type specific covariattes for pseudobulk associaTR model
+    Obtain cell-type specific covariates for pseudobulk associaTR model
 
     """
     b = get_batch()

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -27,9 +27,8 @@ def get_covariates(pseudobulk_input_dir, cell_type, chromosomes, covariate_file_
     # read in and concatenate pseudobulk data (chr-specific --> genome-wide anndata)
     adatas = []
     for i in chromosomes.split(','):
-        gcs_file_path = (
-            f'{pseudobulk_input_dir}/{cell_type}/{cell_type}_chr{i}_pseudobulk.csv'
-        )
+        gcs_file_path = f'{pseudobulk_input_dir}/{cell_type}/{cell_type}_chr{i}_pseudobulk.csv'
+
         local_file_path = to_path(gcs_file_path).copy('here.csv')
         adata = sc.read_csv(local_file_path)
         adatas.append(adata)

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -4,8 +4,9 @@ This script calculates cell-type specific PCs from the pseudobulk RNA data (geno
 merges them with other pre-calculated covariates, and writes the file to GCP.
 
 analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
---description "Get covariates" --output-dir "str/associatr/input_files" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/input_files/pseudobulk \
---cell-types=ASDC --chromosomes=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 --covariate-file-path=gs://cpg-bioheart-test/str/anndata/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv
+--description "Get covariates" --output-dir "str/associatr/input_files/rna_pc_calibration/2_pcs" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/input_files/pseudobulk \
+--cell-types=CD8_TEM --chromosomes=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 --covariate-file-path=gs://cpg-bioheart-test/str/anndata/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv \
+--num-pcs=2
 
 """
 
@@ -59,9 +60,7 @@ def get_covariates(
     sc.pl.pca_variance_ratio(adata_genome, save='local.png')
     hl.hadoop_copy(
         'figures/pca_variance_ratiolocal.png',
-        output_path(
-            f'pseudobulk_RNA_PCs_scree_plots/{cell_type}_scree_plot.png', 'analysis'
-        ),
+        output_path(f'pseudobulk_RNA_PCs_scree_plots/{cell_type}_scree_plot.png'),
     )
 
     # extract PCs
@@ -85,14 +84,11 @@ def get_covariates(
     # Drop columns from 'geno_PC7' onwards (use the first 6 geno PCs only)
     cov = cov.iloc[:, :index_of_geno_PC7]
 
-
     merged_df = pd.merge(cov, df_pcs, on='sample_id')
 
     # write to GCP
     merged_df.to_csv(
-        output_path(
-            f'covariates/{num_pcs}_rna_pcs/{cell_type}_covariates.csv', 'analysis'
-        ),
+        output_path(f'covariates/{num_pcs}_rna_pcs/{cell_type}_covariates.csv'),
         index=False,
     )
 


### PR DESCRIPTION
This script calculates cell-type specific PCs from the pseudobulk RNA data (genome-wide),
merges them with other pre-calculated covariates (from Anna's pipeline), and writes the file to GCP.

`chromosomes` is added as an arg because at this stage not sure if we want to add in chrX or not. So keeping it as an arg for the flexibility. 

Successsful batch - https://batch.hail.populationgenomics.org.au/batches/434148/jobs/1
