### PR TITLE
Create QC_annotator.py

### DIFF
--- a/str/qc/qc_annotator.py
+++ b/str/qc/qc_annotator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # pylint: disable=missing-function-docstring,no-member
 """
-This script annotates the MT with the following annotations:
+This script annotates the ExpansionHunter MT with the following annotations:
 - rep_length_alleles: repeat length of each allele
 - motif_length: length of the motif
 - bp_length_alleles: bp length of each allele

--- a/str/qc/qc_annotator.py
+++ b/str/qc/qc_annotator.py
@@ -62,16 +62,14 @@ def main(mt_path):
             )
         )
     )
-    # motif length
-    mt = mt.annotate_rows(motif_length=hl.len(mt.info.RU))
 
-    # bp length array annotation: motif length*repeat length
+    # motif length, bp length array annotation: motif length*repeat length
     mt = mt.annotate_rows(
+        motif_length=hl.len(mt.info.RU),
         bp_length_alleles=mt.rep_length_alleles.map(lambda x: x * mt.motif_length)
     )
     # break up allele_1 and allele_2 into separate columns
-    mt = mt.annotate_entries(allele_1_rep_length=hl.int(mt.REPCN.split('/')[0]))
-    mt = mt.annotate_entries(
+    mt = mt.annotate_entries(allele_1_rep_length=hl.int(mt.REPCN.split('/')[0]),
         allele_2_rep_length=hl.if_else(
             hl.len(mt.REPCN.split('/')) == 2,
             hl.int(mt.REPCN.split('/')[1]),
@@ -79,9 +77,7 @@ def main(mt_path):
         )
     )
     mt = mt.annotate_entries(
-        allele_1_bp_length=mt.allele_1_rep_length * mt.motif_length
-    )
-    mt = mt.annotate_entries(
+        allele_1_bp_length=mt.allele_1_rep_length * mt.motif_length,
         allele_2_bp_length=mt.allele_2_rep_length * mt.motif_length
     )
 
@@ -118,17 +114,13 @@ def main(mt_path):
 
     # the difference between each allele and the mode allele
     mt = mt.annotate_entries(
-        allele_1_minus_mode=mt.allele_1_rep_length - mt.aggregated_info.mode_allele
-    )
-    mt = mt.annotate_entries(
+        allele_1_minus_mode=mt.allele_1_rep_length - mt.aggregated_info.mode_allele,
         allele_2_minus_mode=mt.allele_2_rep_length - mt.aggregated_info.mode_allele
     )
 
     # annotate the sum of alleles that are not the mode allele
     mt = mt.annotate_entries(
-        allele_1_is_non_mode=hl.if_else(mt.allele_1_minus_mode != 0, True, False)
-    )
-    mt = mt.annotate_entries(
+        allele_1_is_non_mode=hl.if_else(mt.allele_1_minus_mode != 0, True, False),
         allele_2_is_non_mode=hl.if_else(mt.allele_2_minus_mode != 0, True, False)
     )
     mt = mt.annotate_rows(

--- a/str/qc/qc_annotator.py
+++ b/str/qc/qc_annotator.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-function-docstring,no-member
+"""
+This script annotates the MT with the following annotations:
+- rep_length_alleles: repeat length of each allele
+- motif_length: length of the motif
+- bp_length_alleles: bp length of each allele
+- allele_1_rep_length: repeat length of allele 1
+- allele_2_rep_length: repeat length of allele 2
+- allele_1_bp_length: bp length of allele 1
+- allele_2_bp_length: bp length of allele 2
+- aggregated_info.mode_allele:mode allele at each locus
+- num_alleles: number of alleles at each locus
+- allele_1_minus_mode: difference between allele 1 and mode allele
+- allele_2_minus_mode: difference between allele 2 and mode allele
+- sum_alleles_is_not_mode: count of non-mode alleles at each locus
+- prop_alleles_is_not_mode: proportion of alleles that are not the mode allele per locus
+- binom_hwep: binomial Hardy-Weinberg equilibrium p-value
+- obs_het: proportion of observed heterozygous calls per locus
+
+analysis-runner --access-level "test" --dataset "bioheart" --description "QC annotator" --output-dir "str/polymorphic_run_n2045/annotated_mt/v2" qc_annotator.py \
+--mt-path=gs://cpg-bioheart-test/str/polymorphic_run_n2045/mt/v1/str.mt
+
+"""
+
+import hail as hl
+import click
+
+from cpg_utils.config import get_config
+
+from cpg_utils.hail_batch import init_batch,output_path
+
+config = get_config()
+
+@click.option('--mt-path', help='GCS Path to the input MT')
+@click.command()
+def main(mt_path):
+
+    init_batch(worker_memory='highmem')
+    mt = hl.read_matrix_table(mt_path)
+    print(f'MT dimensions: {mt.count()}')
+
+    # sample_qc and variant_qc function
+    mt = hl.sample_qc(mt)
+    mt = hl.variant_qc(mt)
+
+    # change key (as two variants can have the same locus coordinates, but different REPID)
+    mt = mt.annotate_rows(REPID=mt.info.REPID)
+    mt = mt.key_rows_by('REPID')
+
+    # clean up repeat length representation - remove 'STR'
+    mt = mt.annotate_rows(
+        rep_length_alleles=mt.alleles.map(
+            lambda x: hl.if_else(
+                x.contains("STR"),
+                hl.int(x.replace("^<STR([0-9]+)>", "$1")),
+                mt.info.REF,
+            )
+        )
+    )
+    # motif length
+    mt = mt.annotate_rows(motif_length = hl.len(mt.info.RU))
+
+    # bp length array annotation: motif length*repeat length
+    mt = mt.annotate_rows(
+        bp_length_alleles=mt.rep_length_alleles.map(
+            lambda x:
+                x*mt.motif_length
+            )
+        )
+    # break up allele_1 and allele_2 into separate columns
+    mt = mt.annotate_entries(allele_1_rep_length=hl.int(mt.REPCN.split("/")[0]))
+    mt = mt.annotate_entries(allele_2_rep_length = hl.if_else(hl.len(mt.REPCN.split("/")) ==2, hl.int(mt.REPCN.split("/")[1]), hl.missing('int32')))
+    mt = mt.annotate_entries(allele_1_bp_length= mt.allele_1_rep_length*mt.motif_length)
+    mt = mt.annotate_entries(allele_2_bp_length= mt.allele_2_rep_length*mt.motif_length)
+
+    # annotate rows with counts of alleles that appear in each VARID
+    ht = mt.select_rows(
+        alleles_rep_lengths = hl.agg.collect(mt.allele_1_rep_length)
+            .extend(hl.agg.collect(mt.allele_2_rep_length))
+    ).rows()
+
+    # explode the allele_array to create one row for each element in the array
+    exploded_table = ht.explode(ht.alleles_rep_lengths)
+
+    # aggregate the counts for each distinct value in the exploded allele_array
+    aggregated_table = exploded_table.group_by(exploded_table.REPID).aggregate(
+        allele_array_counts=hl.agg.counter(exploded_table.alleles_rep_lengths)
+    )
+
+    # finds the mode allele at each locus
+    max_key_expr = hl.bind(lambda d: hl.bind(lambda kv: kv[0], hl.sorted(d.items(), key=lambda kv: -kv[1])[0]), aggregated_table.allele_array_counts)
+    aggregated_table = aggregated_table.annotate(mode_allele=max_key_expr)
+
+    # annotate the mode allele and dictionary of frequency of each allele into mt
+    mt = mt.annotate_rows(aggregated_info = aggregated_table[mt.REPID])
+    # number of distinct alleles identified at each locus
+    mt = mt.annotate_rows(num_alleles = hl.len(mt.aggregated_info.allele_array_counts.values()))
+
+    # the difference between each allele and the mode allele
+    mt = mt.annotate_entries(allele_1_minus_mode = mt.allele_1_rep_length- mt.aggregated_info.mode_allele)
+    mt = mt.annotate_entries(allele_2_minus_mode = mt.allele_2_rep_length-mt.aggregated_info.mode_allele)
+
+    # annotate the sum of alleles that are not the mode allele
+    mt = mt.annotate_entries(allele_1_is_non_mode = hl.if_else(mt.allele_1_minus_mode!=0, True, False))
+    mt = mt.annotate_entries(allele_2_is_non_mode = hl.if_else(mt.allele_2_minus_mode!=0, True, False))
+    mt = mt.annotate_rows(sum_allele_1_is_not_mode=hl.agg.sum(hl.cond(mt.allele_1_is_non_mode, 1, 0)),
+                         sum_allele_2_is_not_mode=hl.agg.sum(hl.cond(mt.allele_2_is_non_mode, 1, 0)))
+    mt = mt.annotate_rows(sum_alleles_is_not_mode = mt.sum_allele_1_is_not_mode + mt.sum_allele_2_is_not_mode)
+    mt = mt.drop('sum_allele_1_is_not_mode', 'sum_allele_2_is_not_mode')
+
+    # proportion of alleles that are not the mode allele
+    mt = mt.annotate_rows(prop_alleles_is_not_mode = mt.sum_alleles_is_not_mode/hl.sum(mt.aggregated_info.allele_array_counts.values()))
+
+    # add in Gymrek binomial HWEP implementation (Hail Query's HWEP implementation only works for biallelic loci)
+    # https://github.com/gymrek-lab/TRTools/blob/master/trtools/utils/utils.py#L325
+    mt = mt.annotate_rows(n_hom = mt.variant_qc.n_called - mt.variant_qc.n_het)
+    mt = mt.annotate_rows(exp_hom_frac = hl.sum(mt.variant_qc.AF**2))
+    mt = mt.annotate_rows(n_hom = hl.int32(mt.n_hom))
+    mt = mt.annotate_rows(n_called = hl.int32(mt.variant_qc.n_called))
+    mt = mt.annotate_rows(binom_hwep = hl.binom_test(mt.n_hom, mt.n_called, mt.exp_hom_frac, 'two-sided'))
+    mt = mt.drop('n_hom', 'n_called', 'exp_hom_frac')
+
+    # proportion of observed heterozygous calls per locus
+    mt = mt.annotate_rows(obs_het = mt.variant_qc.n_het/mt.variant_qc.n_called)
+
+    #average 'locus coverage' per locus
+    mt = mt.annotate_rows(variant_lc = hl.agg.sum(mt.LC)/mt.variant_qc.n_called)
+
+    #confidence interval (CI) annotations
+    mt = mt.annotate_entries(allele_1_REPCI=hl.str(mt.REPCI.split("/")[0]),
+                            allele_2_REPCI=hl.if_else(hl.len(mt.REPCN.split("/")) ==2, hl.str(mt.REPCI.split("/")[1]), hl.missing('str')))
+    mt = mt.annotate_entries(allele_1_REPCI_1=hl.int32(mt.allele_1_REPCI.split("-")[0]),
+                            allele_1_REPCI_2=hl.int32(mt.allele_1_REPCI.split("-")[1]))
+    mt = mt.annotate_entries(allele_2_REPCI_1 = hl.if_else(hl.len(mt.allele_2_REPCI.split("-")) ==2, hl.int(mt.allele_2_REPCI.split("-")[0]), hl.missing('int32')))
+    mt = mt.annotate_entries(allele_2_REPCI_2 = hl.if_else(hl.len(mt.allele_2_REPCI.split("-")) ==2, hl.int(mt.allele_2_REPCI.split("-")[1]), hl.missing('int32')))
+    mt = mt.annotate_entries(allele_1_REPCI_size=hl.int32(mt.allele_1_REPCI_2 - mt.allele_1_REPCI_1),
+                            allele_2_REPCI_size=hl.int32(mt.allele_2_REPCI_2 - mt.allele_2_REPCI_1))
+    mt = mt.annotate_entries(allele_1_REPCI_over_CN=hl.float64(mt.allele_1_REPCI_size/mt.allele_1_rep_length),
+                            allele_2_REPCI_over_CN=hl.float64(mt.allele_2_REPCI_size/mt.allele_2_rep_length))
+    mt = mt.drop('allele_1_REPCI_1', 'allele_1_REPCI_2', 'allele_2_REPCI_1', 'allele_2_REPCI_2','allele_1_REPCI', 'allele_2_REPCI')
+
+    # write out mt to GCS path
+    mt.write(output_path('str_annotated.mt'))
+
+    # print mt schema
+    mt.describe()
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/str/qc/qc_annotator.py
+++ b/str/qc/qc_annotator.py
@@ -141,10 +141,10 @@ def main(mt_path):
 
     # add in Gymrek binomial HWEP implementation (Hail Query's HWEP implementation only works for biallelic loci)
     # https://github.com/gymrek-lab/TRTools/blob/master/trtools/utils/utils.py#L325
-    mt = mt.annotate_rows(n_hom=mt.variant_qc.n_called - mt.variant_qc.n_het)
-    mt = mt.annotate_rows(exp_hom_frac=hl.sum(mt.variant_qc.AF**2))
+    mt = mt.annotate_rows(n_hom=mt.variant_qc.n_called - mt.variant_qc.n_het,
+                        exp_hom_frac=hl.sum(mt.variant_qc.AF**2),
+                        n_called=hl.int32(mt.variant_qc.n_called))
     mt = mt.annotate_rows(n_hom=hl.int32(mt.n_hom))
-    mt = mt.annotate_rows(n_called=hl.int32(mt.variant_qc.n_called))
     mt = mt.annotate_rows(
         binom_hwep=hl.binom_test(mt.n_hom, mt.n_called, mt.exp_hom_frac, 'two-sided')
     )
@@ -168,15 +168,11 @@ def main(mt_path):
     mt = mt.annotate_entries(
         allele_1_REPCI_1=hl.int32(mt.allele_1_REPCI.split('-')[0]),
         allele_1_REPCI_2=hl.int32(mt.allele_1_REPCI.split('-')[1]),
-    )
-    mt = mt.annotate_entries(
         allele_2_REPCI_1=hl.if_else(
             hl.len(mt.allele_2_REPCI.split('-')) == 2,
             hl.int(mt.allele_2_REPCI.split('-')[0]),
             hl.missing('int32'),
-        )
-    )
-    mt = mt.annotate_entries(
+        ),
         allele_2_REPCI_2=hl.if_else(
             hl.len(mt.allele_2_REPCI.split('-')) == 2,
             hl.int(mt.allele_2_REPCI.split('-')[1]),

--- a/str/qc/qc_annotator.py
+++ b/str/qc/qc_annotator.py
@@ -66,19 +66,20 @@ def main(mt_path):
     # motif length, bp length array annotation: motif length*repeat length
     mt = mt.annotate_rows(
         motif_length=hl.len(mt.info.RU),
-        bp_length_alleles=mt.rep_length_alleles.map(lambda x: x * mt.motif_length)
+        bp_length_alleles=mt.rep_length_alleles.map(lambda x: x * mt.motif_length),
     )
     # break up allele_1 and allele_2 into separate columns
-    mt = mt.annotate_entries(allele_1_rep_length=hl.int(mt.REPCN.split('/')[0]),
+    mt = mt.annotate_entries(
+        allele_1_rep_length=hl.int(mt.REPCN.split('/')[0]),
         allele_2_rep_length=hl.if_else(
             hl.len(mt.REPCN.split('/')) == 2,
             hl.int(mt.REPCN.split('/')[1]),
             hl.missing('int32'),
-        )
+        ),
     )
     mt = mt.annotate_entries(
         allele_1_bp_length=mt.allele_1_rep_length * mt.motif_length,
-        allele_2_bp_length=mt.allele_2_rep_length * mt.motif_length
+        allele_2_bp_length=mt.allele_2_rep_length * mt.motif_length,
     )
 
     # annotate rows with counts of alleles that appear in each VARID
@@ -115,13 +116,13 @@ def main(mt_path):
     # the difference between each allele and the mode allele
     mt = mt.annotate_entries(
         allele_1_minus_mode=mt.allele_1_rep_length - mt.aggregated_info.mode_allele,
-        allele_2_minus_mode=mt.allele_2_rep_length - mt.aggregated_info.mode_allele
+        allele_2_minus_mode=mt.allele_2_rep_length - mt.aggregated_info.mode_allele,
     )
 
     # annotate the sum of alleles that are not the mode allele
     mt = mt.annotate_entries(
         allele_1_is_non_mode=hl.if_else(mt.allele_1_minus_mode != 0, True, False),
-        allele_2_is_non_mode=hl.if_else(mt.allele_2_minus_mode != 0, True, False)
+        allele_2_is_non_mode=hl.if_else(mt.allele_2_minus_mode != 0, True, False),
     )
     mt = mt.annotate_rows(
         sum_allele_1_is_not_mode=hl.agg.sum(hl.cond(mt.allele_1_is_non_mode, 1, 0)),
@@ -141,9 +142,11 @@ def main(mt_path):
 
     # add in Gymrek binomial HWEP implementation (Hail Query's HWEP implementation only works for biallelic loci)
     # https://github.com/gymrek-lab/TRTools/blob/master/trtools/utils/utils.py#L325
-    mt = mt.annotate_rows(n_hom=mt.variant_qc.n_called - mt.variant_qc.n_het,
-                        exp_hom_frac=hl.sum(mt.variant_qc.AF**2),
-                        n_called=hl.int32(mt.variant_qc.n_called))
+    mt = mt.annotate_rows(
+        n_hom=mt.variant_qc.n_called - mt.variant_qc.n_het,
+        exp_hom_frac=hl.sum(mt.variant_qc.AF**2),
+        n_called=hl.int32(mt.variant_qc.n_called),
+    )
     mt = mt.annotate_rows(n_hom=hl.int32(mt.n_hom))
     mt = mt.annotate_rows(
         binom_hwep=hl.binom_test(mt.n_hom, mt.n_called, mt.exp_hom_frac, 'two-sided')
@@ -177,7 +180,7 @@ def main(mt_path):
             hl.len(mt.allele_2_REPCI.split('-')) == 2,
             hl.int(mt.allele_2_REPCI.split('-')[1]),
             hl.missing('int32'),
-        )
+        ),
     )
     mt = mt.annotate_entries(
         allele_1_REPCI_size=hl.int32(mt.allele_1_REPCI_2 - mt.allele_1_REPCI_1),

--- a/str/qc/qc_annotator.py
+++ b/str/qc/qc_annotator.py
@@ -36,6 +36,9 @@ config = get_config()
 @click.option('--mt-path', help='GCS Path to the input MT')
 @click.command()
 def main(mt_path):
+    """
+    Annotates the ExpansionHunter MT, and outputs annotated MT to GCS
+    """
 
     init_batch(worker_memory='highmem')
     mt = hl.read_matrix_table(mt_path)

--- a/str/qc/qc_annotator.py
+++ b/str/qc/qc_annotator.py
@@ -28,9 +28,10 @@ import click
 
 from cpg_utils.config import get_config
 
-from cpg_utils.hail_batch import init_batch,output_path
+from cpg_utils.hail_batch import init_batch, output_path
 
 config = get_config()
+
 
 @click.option('--mt-path', help='GCS Path to the input MT')
 @click.command()
@@ -52,32 +53,40 @@ def main(mt_path):
     mt = mt.annotate_rows(
         rep_length_alleles=mt.alleles.map(
             lambda x: hl.if_else(
-                x.contains("STR"),
-                hl.int(x.replace("^<STR([0-9]+)>", "$1")),
+                x.contains('STR'),
+                hl.int(x.replace('^<STR([0-9]+)>', '$1')),
                 mt.info.REF,
             )
         )
     )
     # motif length
-    mt = mt.annotate_rows(motif_length = hl.len(mt.info.RU))
+    mt = mt.annotate_rows(motif_length=hl.len(mt.info.RU))
 
     # bp length array annotation: motif length*repeat length
     mt = mt.annotate_rows(
-        bp_length_alleles=mt.rep_length_alleles.map(
-            lambda x:
-                x*mt.motif_length
-            )
-        )
+        bp_length_alleles=mt.rep_length_alleles.map(lambda x: x * mt.motif_length)
+    )
     # break up allele_1 and allele_2 into separate columns
-    mt = mt.annotate_entries(allele_1_rep_length=hl.int(mt.REPCN.split("/")[0]))
-    mt = mt.annotate_entries(allele_2_rep_length = hl.if_else(hl.len(mt.REPCN.split("/")) ==2, hl.int(mt.REPCN.split("/")[1]), hl.missing('int32')))
-    mt = mt.annotate_entries(allele_1_bp_length= mt.allele_1_rep_length*mt.motif_length)
-    mt = mt.annotate_entries(allele_2_bp_length= mt.allele_2_rep_length*mt.motif_length)
+    mt = mt.annotate_entries(allele_1_rep_length=hl.int(mt.REPCN.split('/')[0]))
+    mt = mt.annotate_entries(
+        allele_2_rep_length=hl.if_else(
+            hl.len(mt.REPCN.split('/')) == 2,
+            hl.int(mt.REPCN.split('/')[1]),
+            hl.missing('int32'),
+        )
+    )
+    mt = mt.annotate_entries(
+        allele_1_bp_length=mt.allele_1_rep_length * mt.motif_length
+    )
+    mt = mt.annotate_entries(
+        allele_2_bp_length=mt.allele_2_rep_length * mt.motif_length
+    )
 
     # annotate rows with counts of alleles that appear in each VARID
     ht = mt.select_rows(
-        alleles_rep_lengths = hl.agg.collect(mt.allele_1_rep_length)
-            .extend(hl.agg.collect(mt.allele_2_rep_length))
+        alleles_rep_lengths=hl.agg.collect(mt.allele_1_rep_length).extend(
+            hl.agg.collect(mt.allele_2_rep_length)
+        )
     ).rows()
 
     # explode the allele_array to create one row for each element in the array
@@ -89,62 +98,123 @@ def main(mt_path):
     )
 
     # finds the mode allele at each locus
-    max_key_expr = hl.bind(lambda d: hl.bind(lambda kv: kv[0], hl.sorted(d.items(), key=lambda kv: -kv[1])[0]), aggregated_table.allele_array_counts)
+    max_key_expr = hl.bind(
+        lambda d: hl.bind(
+            lambda kv: kv[0], hl.sorted(d.items(), key=lambda kv: -kv[1])[0]
+        ),
+        aggregated_table.allele_array_counts,
+    )
     aggregated_table = aggregated_table.annotate(mode_allele=max_key_expr)
 
     # annotate the mode allele and dictionary of frequency of each allele into mt
-    mt = mt.annotate_rows(aggregated_info = aggregated_table[mt.REPID])
+    mt = mt.annotate_rows(aggregated_info=aggregated_table[mt.REPID])
     # number of distinct alleles identified at each locus
-    mt = mt.annotate_rows(num_alleles = hl.len(mt.aggregated_info.allele_array_counts.values()))
+    mt = mt.annotate_rows(
+        num_alleles=hl.len(mt.aggregated_info.allele_array_counts.values())
+    )
 
     # the difference between each allele and the mode allele
-    mt = mt.annotate_entries(allele_1_minus_mode = mt.allele_1_rep_length- mt.aggregated_info.mode_allele)
-    mt = mt.annotate_entries(allele_2_minus_mode = mt.allele_2_rep_length-mt.aggregated_info.mode_allele)
+    mt = mt.annotate_entries(
+        allele_1_minus_mode=mt.allele_1_rep_length - mt.aggregated_info.mode_allele
+    )
+    mt = mt.annotate_entries(
+        allele_2_minus_mode=mt.allele_2_rep_length - mt.aggregated_info.mode_allele
+    )
 
     # annotate the sum of alleles that are not the mode allele
-    mt = mt.annotate_entries(allele_1_is_non_mode = hl.if_else(mt.allele_1_minus_mode!=0, True, False))
-    mt = mt.annotate_entries(allele_2_is_non_mode = hl.if_else(mt.allele_2_minus_mode!=0, True, False))
-    mt = mt.annotate_rows(sum_allele_1_is_not_mode=hl.agg.sum(hl.cond(mt.allele_1_is_non_mode, 1, 0)),
-                         sum_allele_2_is_not_mode=hl.agg.sum(hl.cond(mt.allele_2_is_non_mode, 1, 0)))
-    mt = mt.annotate_rows(sum_alleles_is_not_mode = mt.sum_allele_1_is_not_mode + mt.sum_allele_2_is_not_mode)
+    mt = mt.annotate_entries(
+        allele_1_is_non_mode=hl.if_else(mt.allele_1_minus_mode != 0, True, False)
+    )
+    mt = mt.annotate_entries(
+        allele_2_is_non_mode=hl.if_else(mt.allele_2_minus_mode != 0, True, False)
+    )
+    mt = mt.annotate_rows(
+        sum_allele_1_is_not_mode=hl.agg.sum(hl.cond(mt.allele_1_is_non_mode, 1, 0)),
+        sum_allele_2_is_not_mode=hl.agg.sum(hl.cond(mt.allele_2_is_non_mode, 1, 0)),
+    )
+    mt = mt.annotate_rows(
+        sum_alleles_is_not_mode=mt.sum_allele_1_is_not_mode
+        + mt.sum_allele_2_is_not_mode
+    )
     mt = mt.drop('sum_allele_1_is_not_mode', 'sum_allele_2_is_not_mode')
 
     # proportion of alleles that are not the mode allele
-    mt = mt.annotate_rows(prop_alleles_is_not_mode = mt.sum_alleles_is_not_mode/hl.sum(mt.aggregated_info.allele_array_counts.values()))
+    mt = mt.annotate_rows(
+        prop_alleles_is_not_mode=mt.sum_alleles_is_not_mode
+        / hl.sum(mt.aggregated_info.allele_array_counts.values())
+    )
 
     # add in Gymrek binomial HWEP implementation (Hail Query's HWEP implementation only works for biallelic loci)
     # https://github.com/gymrek-lab/TRTools/blob/master/trtools/utils/utils.py#L325
-    mt = mt.annotate_rows(n_hom = mt.variant_qc.n_called - mt.variant_qc.n_het)
-    mt = mt.annotate_rows(exp_hom_frac = hl.sum(mt.variant_qc.AF**2))
-    mt = mt.annotate_rows(n_hom = hl.int32(mt.n_hom))
-    mt = mt.annotate_rows(n_called = hl.int32(mt.variant_qc.n_called))
-    mt = mt.annotate_rows(binom_hwep = hl.binom_test(mt.n_hom, mt.n_called, mt.exp_hom_frac, 'two-sided'))
+    mt = mt.annotate_rows(n_hom=mt.variant_qc.n_called - mt.variant_qc.n_het)
+    mt = mt.annotate_rows(exp_hom_frac=hl.sum(mt.variant_qc.AF**2))
+    mt = mt.annotate_rows(n_hom=hl.int32(mt.n_hom))
+    mt = mt.annotate_rows(n_called=hl.int32(mt.variant_qc.n_called))
+    mt = mt.annotate_rows(
+        binom_hwep=hl.binom_test(mt.n_hom, mt.n_called, mt.exp_hom_frac, 'two-sided')
+    )
     mt = mt.drop('n_hom', 'n_called', 'exp_hom_frac')
 
     # proportion of observed heterozygous calls per locus
-    mt = mt.annotate_rows(obs_het = mt.variant_qc.n_het/mt.variant_qc.n_called)
+    mt = mt.annotate_rows(obs_het=mt.variant_qc.n_het / mt.variant_qc.n_called)
 
-    #average 'locus coverage' per locus
-    mt = mt.annotate_rows(variant_lc = hl.agg.sum(mt.LC)/mt.variant_qc.n_called)
+    # average 'locus coverage' per locus
+    mt = mt.annotate_rows(variant_lc=hl.agg.sum(mt.LC) / mt.variant_qc.n_called)
 
-    #confidence interval (CI) annotations
-    mt = mt.annotate_entries(allele_1_REPCI=hl.str(mt.REPCI.split("/")[0]),
-                            allele_2_REPCI=hl.if_else(hl.len(mt.REPCN.split("/")) ==2, hl.str(mt.REPCI.split("/")[1]), hl.missing('str')))
-    mt = mt.annotate_entries(allele_1_REPCI_1=hl.int32(mt.allele_1_REPCI.split("-")[0]),
-                            allele_1_REPCI_2=hl.int32(mt.allele_1_REPCI.split("-")[1]))
-    mt = mt.annotate_entries(allele_2_REPCI_1 = hl.if_else(hl.len(mt.allele_2_REPCI.split("-")) ==2, hl.int(mt.allele_2_REPCI.split("-")[0]), hl.missing('int32')))
-    mt = mt.annotate_entries(allele_2_REPCI_2 = hl.if_else(hl.len(mt.allele_2_REPCI.split("-")) ==2, hl.int(mt.allele_2_REPCI.split("-")[1]), hl.missing('int32')))
-    mt = mt.annotate_entries(allele_1_REPCI_size=hl.int32(mt.allele_1_REPCI_2 - mt.allele_1_REPCI_1),
-                            allele_2_REPCI_size=hl.int32(mt.allele_2_REPCI_2 - mt.allele_2_REPCI_1))
-    mt = mt.annotate_entries(allele_1_REPCI_over_CN=hl.float64(mt.allele_1_REPCI_size/mt.allele_1_rep_length),
-                            allele_2_REPCI_over_CN=hl.float64(mt.allele_2_REPCI_size/mt.allele_2_rep_length))
-    mt = mt.drop('allele_1_REPCI_1', 'allele_1_REPCI_2', 'allele_2_REPCI_1', 'allele_2_REPCI_2','allele_1_REPCI', 'allele_2_REPCI')
+    # confidence interval (CI) annotations
+    mt = mt.annotate_entries(
+        allele_1_REPCI=hl.str(mt.REPCI.split('/')[0]),
+        allele_2_REPCI=hl.if_else(
+            hl.len(mt.REPCN.split('/')) == 2,
+            hl.str(mt.REPCI.split('/')[1]),
+            hl.missing('str'),
+        ),
+    )
+    mt = mt.annotate_entries(
+        allele_1_REPCI_1=hl.int32(mt.allele_1_REPCI.split('-')[0]),
+        allele_1_REPCI_2=hl.int32(mt.allele_1_REPCI.split('-')[1]),
+    )
+    mt = mt.annotate_entries(
+        allele_2_REPCI_1=hl.if_else(
+            hl.len(mt.allele_2_REPCI.split('-')) == 2,
+            hl.int(mt.allele_2_REPCI.split('-')[0]),
+            hl.missing('int32'),
+        )
+    )
+    mt = mt.annotate_entries(
+        allele_2_REPCI_2=hl.if_else(
+            hl.len(mt.allele_2_REPCI.split('-')) == 2,
+            hl.int(mt.allele_2_REPCI.split('-')[1]),
+            hl.missing('int32'),
+        )
+    )
+    mt = mt.annotate_entries(
+        allele_1_REPCI_size=hl.int32(mt.allele_1_REPCI_2 - mt.allele_1_REPCI_1),
+        allele_2_REPCI_size=hl.int32(mt.allele_2_REPCI_2 - mt.allele_2_REPCI_1),
+    )
+    mt = mt.annotate_entries(
+        allele_1_REPCI_over_CN=hl.float64(
+            mt.allele_1_REPCI_size / mt.allele_1_rep_length
+        ),
+        allele_2_REPCI_over_CN=hl.float64(
+            mt.allele_2_REPCI_size / mt.allele_2_rep_length
+        ),
+    )
+    mt = mt.drop(
+        'allele_1_REPCI_1',
+        'allele_1_REPCI_2',
+        'allele_2_REPCI_1',
+        'allele_2_REPCI_2',
+        'allele_1_REPCI',
+        'allele_2_REPCI',
+    )
 
     # write out mt to GCS path
     mt.write(output_path('str_annotated.mt'))
 
     # print mt schema
     mt.describe()
+
 
 if __name__ == '__main__':
     main()  # pylint: disable=no-value-for-parameter

--- a/str/qc/qc_filters_associatr.py
+++ b/str/qc/qc_filters_associatr.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-function-docstring,no-member,unnecessary-lambda
+"""
+This script applies filters to a ExpansionHunter MT, and outputs chromosome-specific VCF ready for input into associaTR.
+Input MT should be the output of qc_annotator.py
+
+Applied filters:
+- remove monomorphic variants
+- locus-level callrate >=0.9
+- sample-level call rate >=0.99
+- observed heterozygosity >=0.00995 (corresponds to a MAF = 0.5%)
+- locus-level HWEP (binom definition) >=10^-6
+- set calls outside of [-30,20] relative to mode to NA
+- enforce locus-level call rate >=0.9
+
+
+ analysis-runner --dataset "bioheart" \
+    --description "Hail QC for associaTR" \
+    --access-level "test" \
+    --output-dir "str/associatr/input_files" \
+    qc_filters_associatr.py --mt-path=gs://cpg-bioheart-test/str/polymorphic_run_n2045/annotated_mt/v2/str_annotated.mt \
+    --version=v1-chr-specific
+
+"""
+
+import hail as hl
+import click
+
+from cpg_utils.config import get_config
+
+from cpg_utils.hail_batch import get_batch, init_batch, output_path
+
+config = get_config()
+
+BCFTOOLS_IMAGE = config['images']['bcftools']
+
+
+def qc_filter(mt_path, version):
+    """
+    Applies QC filters to the input MT
+    """
+    init_batch(worker_memory='highmem')
+
+    # read in mt
+    mt = hl.read_matrix_table(mt_path)
+
+    # remove monomorphic variants, set locus level call rate >=0.9, observed heterozygosity >=0.00995, locus level HWEP (binom definition) >=10^-6
+    mt = mt.filter_rows(
+        (mt.num_alleles > 1)
+        & (mt.variant_qc.call_rate >= 0.9)
+        & (mt.obs_het >= 0.00995)
+        & (mt.binom_hwep >= 0.000001)
+    )
+
+    # set sample level call rate >=0.99
+    mt = mt.filter_cols(mt.sample_qc.call_rate >= 0.99)
+
+    # set big expansions/deletions beyond [-30,20] relative to mode allele to NA
+    condition_allele_1 = (mt.allele_1_minus_mode > 20) | (mt.allele_1_minus_mode < -30)
+    condition_allele_2 = (mt.allele_2_minus_mode > 20) | (mt.allele_2_minus_mode < -30)
+    mt = mt.annotate_entries(
+        GT=hl.if_else(
+            condition_allele_1,
+            hl.missing('call'),
+            mt.GT,
+        ),
+        ADFL=hl.if_else(
+            condition_allele_1,
+            hl.missing('str'),
+            mt.ADFL,
+        ),
+        ADIR=hl.if_else(
+            condition_allele_1,
+            hl.missing('str'),
+            mt.ADIR,
+        ),
+        ADSP=hl.if_else(
+            condition_allele_1,
+            hl.missing('str'),
+            mt.ADSP,
+        ),
+        LC=hl.if_else(
+            condition_allele_1,
+            hl.missing('float64'),
+            mt.LC,
+        ),
+        REPCI=hl.if_else(
+            condition_allele_1,
+            hl.missing('str'),
+            mt.REPCI,
+        ),
+        REPCN=hl.if_else(
+            condition_allele_1,
+            hl.missing('str'),
+            mt.REPCN,
+        ),
+        SO=hl.if_else(
+            condition_allele_1,
+            hl.missing('str'),
+            mt.SO,
+        ),
+    )
+
+    mt = mt.annotate_entries(
+        GT=hl.if_else(
+            condition_allele_2,
+            hl.missing('call'),
+            mt.GT,
+        ),
+        ADFL=hl.if_else(
+            condition_allele_2,
+            hl.missing('str'),
+            mt.ADFL,
+        ),
+        ADIR=hl.if_else(
+            condition_allele_2,
+            hl.missing('str'),
+            mt.ADIR,
+        ),
+        ADSP=hl.if_else(
+            condition_allele_2,
+            hl.missing('str'),
+            mt.ADSP,
+        ),
+        LC=hl.if_else(
+            condition_allele_2,
+            hl.missing('float64'),
+            mt.LC,
+        ),
+        REPCI=hl.if_else(
+            condition_allele_2,
+            hl.missing('str'),
+            mt.REPCI,
+        ),
+        REPCN=hl.if_else(
+            condition_allele_2,
+            hl.missing('str'),
+            mt.REPCN,
+        ),
+        SO=hl.if_else(
+            condition_allele_2,
+            hl.missing('str'),
+            mt.SO,
+        ),
+    )
+
+    # calculate proportion of GTs that are defined per locus (after applying call-level filters, variant_qc.call_rate is not accurate anymore)
+    mt = mt.annotate_rows(
+        prop_GT_exists=hl.agg.count_where(hl.is_defined(mt.GT))
+        / (mt.variant_qc.n_called + mt.variant_qc.n_not_called)
+    )
+    # re-enforce locus level call rate >=0.9
+    mt = mt.filter_rows(mt.prop_GT_exists >= 0.9)
+
+    # wrangle mt, prepare for export_vcf():
+
+    # drop unneccessary columns prior to writing out
+    mt = mt.drop(
+        'allele_1_rep_length',
+        'allele_2_rep_length',
+        'allele_1_bp_length',
+        'allele_2_bp_length',
+        'allele_1_REPCI_over_CN',
+        'allele_2_REPCI_over_CN',
+        'allele_1_minus_mode',
+        'allele_2_minus_mode',
+        'allele_1_REPCI_size',
+        'allele_2_REPCI_size',
+        'allele_1_is_non_mode',
+        'allele_2_is_non_mode',
+    )
+
+    # Set the QUAL field to missing for all rows
+    mt = mt.annotate_entries(QUAL=hl.missing('float64'))
+
+    # Set 'rsid' to REPID
+    mt = mt.annotate_rows(rsid=mt.REPID)
+
+    # Key by locus and alleles
+    mt = mt.key_rows_by('locus', 'alleles')
+
+    # Remove 'CPG' prefix from ID (associaTR expects ID to be numeric)
+    mt = mt.annotate_cols(s_no_prefix=mt.s[3:])
+    mt = mt.key_cols_by(s=mt.s_no_prefix)
+    mt.drop('s_no_prefix')
+
+    for chr_index in range(22):  # iterate over chr1-22
+        mt_chr = mt.filter_rows(mt.locus.contig == f'chr{chr_index + 1}')
+        gcs_output_path = output_path(
+            f'vcf/{version}/hail_filtered_chr{chr_index+1}.vcf.bgz'
+        )
+        # needs STR VCF header text to be recognised by associaTR as an ExpansionHunter VCF
+        hl.export_vcf(
+            mt_chr,
+            gcs_output_path,
+            append_to_header='gs://cpg-tob-wgs-test/hoptan-str/associatr/input_files/hail/STR_header.txt',
+            tabix=True,
+        )
+
+
+@click.option(
+    '--mt-path',
+    help='GCS file path to mt (output of qc_annotator.py)',
+    type=str,
+)
+@click.option('--hail-storage', help='Hail storage', type=str, default='0G')
+@click.option('--hail-cpu', help='Hail CPU', type=int, default=1)
+@click.option('--hail-memory', help='Hail memory', type=str, default='standard')
+@click.option('--version', help='version of the output files', type=str, default='v1')
+@click.command()
+def main(
+    mt_path,
+    hail_storage,
+    hail_cpu,
+    hail_memory,
+    version,
+):
+    """
+    Runner to apply QC filters to input MT, and bgzip and tabix.
+    """
+
+    b = get_batch('Apply QC filters to MT and export chr-specific VCFs')
+
+    hail_job = b.new_python_job(name=f'QC filters')
+    hail_job.image(config['workflow']['driver_image'])
+    hail_job.storage(hail_storage)
+    hail_job.cpu(hail_cpu)
+    hail_job.memory(hail_memory)
+    hail_job.call(qc_filter, mt_path, version)
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
This script annotates the ExpansionHunter MT with the following annotations:
- rep_length_alleles: repeat length of each allele
- motif_length: length of the motif
- bp_length_alleles: bp length of each allele
- allele_1_rep_length: repeat length of allele 1
- allele_2_rep_length: repeat length of allele 2
- allele_1_bp_length: bp length of allele 1
- allele_2_bp_length: bp length of allele 2
- aggregated_info.mode_allele:mode allele at each locus
- num_alleles: number of alleles at each locus
- allele_1_minus_mode: difference between allele 1 and mode allele
- allele_2_minus_mode: difference between allele 2 and mode allele
- sum_alleles_is_not_mode: count of non-mode alleles at each locus
- prop_alleles_is_not_mode: proportion of alleles that are not the mode allele per locus
- binom_hwep: binomial Hardy-Weinberg equilibrium p-value
- obs_het: proportion of observed heterozygous calls per locus


Annotations will be used for downstream filtering. 

This runs without issues on the full `mt` already. 