### PR TITLE
Runner script for gene-level multiple testing correction 

### DIFF
--- a/str/associatr/multiple_testing_correction/run_gene_level_pval.py
+++ b/str/associatr/multiple_testing_correction/run_gene_level_pval.py
@@ -136,6 +136,9 @@ def bonferroni_compute(
     ref_len,
     allele_frequency,
 ):
+    """
+    Computes Bonferroni adjusted p-value of the lowest raw p-value for a gene
+    """
     pval = min(pvals) * len(pvals)
     # write to output
     gcs_output = output_path(
@@ -183,7 +186,7 @@ def bonferroni_compute(
 @click.command()
 def main(input_dir, cell_types, chromosomes, max_parallel_jobs, acat, bonferroni):
     """
-    Compute gene-level p-values using the ACAT method
+    Compute gene-level p-values
     """
     # Setup MAX concurrency by genes
     _dependent_jobs: list[hb.batch.job.Job] = []

--- a/str/associatr/multiple_testing_correction/run_gene_level_pval.py
+++ b/str/associatr/multiple_testing_correction/run_gene_level_pval.py
@@ -9,8 +9,8 @@ The attributes of the locus with the lowest raw p-value are also stored in the T
 
 analysis-runner --dataset "bioheart" --description "compute gene level pvals" --access-level "test" \
     --output-dir "str/associatr/rna_pc_calibration/2_pcs/results" \
-    run_acat.py --input-dir=gs://cpg-bioheart-test/str/associatr/rna_pc_calibration/2_pcs/results/v1 \
-    --cell-types=CD8_TEM --chromosomes=21
+    run_gene_level_pval.py --input-dir=gs://cpg-bioheart-test/str/associatr/rna_pc_calibration/2_pcs/results/v1 \
+    --cell-types=CD8_TEM --chromosomes=21 --acat --bonferroni
 
 """
 import numpy as np
@@ -209,13 +209,13 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs, acat, bonferroni
             for i in range(0, len(gene_files), genes_per_job):
                 batch_gene_files = gene_files[i : i + genes_per_job]
                 j = get_batch('Compute gene level pvals').new_python_job(
-                    name=f'Compute gene-level ACAT p-values for genes {i+1}-{i+genes_per_job}'
+                    name=f'Compute gene-level p-values for genes {i+1}-{i+genes_per_job}'
                 )
                 j.cpu(0.25).memory('lowmem')
-                f = get_batch('Compute gene level pvals').new_python_job(
-                    name=f'Compute gene-level Bonferroni p-values for genes {i+1}-{i+genes_per_job}'
-                )
-                f.cpu(0.25).memory('lowmem')
+                #f = get_batch('Compute gene level pvals').new_python_job(
+                #    name=f'Compute gene-level Bonferroni p-values for genes {i+1}-{i+genes_per_job}'
+                #)
+                #f.cpu(0.25).memory('lowmem')
                 for gene_file in batch_gene_files:
                     # read the raw results
                     gene_results = pd.read_csv(gene_file, sep='\t')
@@ -280,7 +280,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs, acat, bonferroni
                             allele_frequency,
                         )
                     if bonferroni:
-                        f.call(
+                        j.call(
                             bonferroni_compute,
                             gene_name,
                             pvals,

--- a/str/associatr/multiple_testing_correction/run_gene_level_pval.py
+++ b/str/associatr/multiple_testing_correction/run_gene_level_pval.py
@@ -120,7 +120,9 @@ def cct(
             f'gene_name\tgene_level_pval\tchr\tpos\tn_samples_tested\tlowest_raw_pval\tcoeff\tse\tr2\tmotif\tref_len\tallele_freq\n'
         )
         f.write(f'{gene_name}\t{pval}\t')
-        f.write('\t'.join([str(row_dict[key]) for key, _value in VALUES_TO_INDEXES]) + '\n')
+        f.write(
+            '\t'.join([str(row_dict[key]) for key, _value in VALUES_TO_INDEXES]) + '\n'
+        )
 
 
 def bonferroni_compute(
@@ -144,7 +146,9 @@ def bonferroni_compute(
             f'gene_name\tgene_level_pval\tchr\tpos\tn_samples_tested\tlowest_raw_pval\tcoeff\tse\tr2\tmotif\tref_len\tallele_freq\n'
         )
         f.write(f'{gene_name}\t{pval}\t')
-        f.write('\t'.join([str(row_dict[key]) for key, _value in VALUES_TO_INDEXES]) + '\n')
+        f.write(
+            '\t'.join([str(row_dict[key]) for key, _value in VALUES_TO_INDEXES]) + '\n'
+        )
 
 
 @click.option(

--- a/str/associatr/multiple_testing_correction/run_gene_level_pval.py
+++ b/str/associatr/multiple_testing_correction/run_gene_level_pval.py
@@ -199,7 +199,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs, acat, bonferroni
             job.depends_on(_dependent_jobs[-max_parallel_jobs])
         _dependent_jobs.append(job)
 
-    genes_per_job = 70
+    genes_per_job = 50
 
     for cell_type in cell_types.split(','):
         for chromosome in chromosomes.split(','):

--- a/str/associatr/multiple_testing_correction/run_gene_level_pval.py
+++ b/str/associatr/multiple_testing_correction/run_gene_level_pval.py
@@ -8,10 +8,9 @@ Output is multiple gene-specific TSV files with the gene name in the first colum
 The attributes of the locus with the lowest raw p-value are also stored in the TSV file (coordinates, beta, se, raw pval,r2, motif, ref_len).
 
 analysis-runner --dataset "bioheart" --description "compute gene level pvals" --access-level "test" \
-    --output-dir "str/associatr/rna_pc_calibration/24_pcs/chr_1/results" \
-    run_gene_level_pval.py --input-dir=gs://cpg-bioheart-test/str/associatr/rna_pc_calibration/24_pcs/results/v1 \
-    --cell-types=CD8_TEM --chromosomes=1 --acat --bonferroni
-
+    --output-dir "str/associatr/240_libraries_tenk10kp1_v2_run/results" \
+    run_gene_level_pval.py --input-dir=gs://cpg-bioheart-test/str/associatr/240_libraries_tenk10kp1_v2_run/results/v1 \
+    --cell-types=CD4_TCM --chromosomes=21 --acat
 """
 import numpy as np
 from scipy.stats import cauchy
@@ -121,7 +120,7 @@ def cct(
             f'gene_name\tgene_level_pval\tchr\tpos\tn_samples_tested\tlowest_raw_pval\tcoeff\tse\tr2\tmotif\tref_len\tallele_freq\n'
         )
         f.write(f'{gene_name}\t{pval}\t')
-        f.write('\t'.join([row_dict[key] for key, _value in VALUES_TO_INDEXES]) + '\n')
+        f.write('\t'.join([str(row_dict[key]) for key, _value in VALUES_TO_INDEXES]) + '\n')
 
 
 def bonferroni_compute(
@@ -145,7 +144,7 @@ def bonferroni_compute(
             f'gene_name\tgene_level_pval\tchr\tpos\tn_samples_tested\tlowest_raw_pval\tcoeff\tse\tr2\tmotif\tref_len\tallele_freq\n'
         )
         f.write(f'{gene_name}\t{pval}\t')
-        f.write('\t'.join([row_dict[key] for key, _value in VALUES_TO_INDEXES]) + '\n')
+        f.write('\t'.join([str(row_dict[key]) for key, _value in VALUES_TO_INDEXES]) + '\n')
 
 
 @click.option(

--- a/str/associatr/multiple_testing_correction/run_gene_level_pval.py
+++ b/str/associatr/multiple_testing_correction/run_gene_level_pval.py
@@ -199,7 +199,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs, acat, bonferroni
             job.depends_on(_dependent_jobs[-max_parallel_jobs])
         _dependent_jobs.append(job)
 
-    genes_per_job = 50
+    genes_per_job = 70
 
     for cell_type in cell_types.split(','):
         for chromosome in chromosomes.split(','):
@@ -212,10 +212,10 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs, acat, bonferroni
                     name=f'Compute gene-level p-values for genes {i+1}-{i+genes_per_job}'
                 )
                 j.cpu(0.25).memory('lowmem')
-                #f = get_batch('Compute gene level pvals').new_python_job(
-                #    name=f'Compute gene-level Bonferroni p-values for genes {i+1}-{i+genes_per_job}'
-                #)
-                #f.cpu(0.25).memory('lowmem')
+                f = get_batch('Compute gene level pvals').new_python_job(
+                    name=f'Compute gene-level Bonferroni p-values for genes {i+1}-{i+genes_per_job}'
+                )
+                f.cpu(0.25).memory('lowmem')
                 for gene_file in batch_gene_files:
                     # read the raw results
                     gene_results = pd.read_csv(gene_file, sep='\t')
@@ -280,7 +280,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs, acat, bonferroni
                             allele_frequency,
                         )
                     if bonferroni:
-                        j.call(
+                        f.call(
                             bonferroni_compute,
                             gene_name,
                             pvals,

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -172,9 +172,9 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs):
                     pvals = gene_results.iloc[:, 5]  # stored in the 6th column
                     # Find and store the attributes of the locus with lowest raw pval
                     # Find the minimum value in column 6
-                    min_value = df.iloc[:, 5].min()
+                    min_value = gene_results.iloc[:, 5].min()
                     # Find the rows with the minimum value in column 6
-                    min_rows = df[df.iloc[:, 5] == min_value]
+                    min_rows = gene_results[gene_results.iloc[:, 5] == min_value]
 
                     if len(min_rows) == 1:
                         chr = [min_rows.iloc[:, 0].values[0]]

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -142,7 +142,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs):
                 to_path(f'{input_dir}/{cell_type}/chr{chromosome}').glob('*.tsv')
             )
             for i in range(0, len(gene_files), genes_per_job):
-                batch_gene_files = gene_files[i:i+genes_per_job]
+                batch_gene_files = gene_files[i : i + genes_per_job]
                 j = get_batch('Compute gene level pvals').new_python_job(
                     name=f'Compute gene-level p-values for genes {i+1}-{i+genes_per_job}'
                 )

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# pylint: disable=too-many-arguments,too-many-locals
+
+"""
+
+This script computes gene-level p-values using ACAT.
+
+"""
+import numpy as np
+from scipy.stats import cauchy
+
+import click
+
+def CCT(pvals, weights=None):
+    """
+    Code adapted from the STAR package https://github.com/xihaoli/STAAR/blob/dc4f7e509f4fa2fb8594de48662bbd06a163108c/R/CCT.R wtih a modifitcaiton: when indiviudal p-value = 1, use minimum p-value
+    #' An analytical p-value combination method using the Cauchy distribution
+    #'
+    #' The \code{CCT} function takes in a numeric vector of p-values, a numeric
+    #' vector of non-negative weights, and return the aggregated p-value using Cauchy method.
+    #' @param pvals a numeric vector of p-values, where each of the element is
+    #' between 0 to 1, to be combined.
+    #' @param weights a numeric vector of non-negative weights. If \code{NULL}, the
+    #' equal weights are assumed.
+    #' @return the aggregated p-value combining p-values from the vector \code{pvals}.
+    #' @examples pvalues <- c(2e-02,4e-04,0.2,0.1,0.8)
+    #' @examples CCT(pvals=pvalues)
+    #' @references Liu, Y., & Xie, J. (2020). Cauchy combination test: a powerful test
+    #' with analytic p-value calculation under arbitrary dependency structures.
+    #' \emph{Journal of the American Statistical Association 115}(529), 393-402.
+    #' (\href{https://www.tandfonline.com/doi/full/10.1080/01621459.2018.1554485}{pub})
+    #' @export
+    R code is implemented in python
+    """
+
+    #check if there is NA
+    if np.isnan(pvals).sum() >0:
+        raise ValueError("Cannot have NAs in the p-values!")
+
+    # check if all p-values are between 0 and 1
+    if ((pvals < 0).sum() + (pvals > 1).sum()) > 0:
+        raise ValueError("All p-values must be between 0 and 1!")
+
+    # check if there are p-values that are either exactly 0 or 1.
+    is_zero = (pvals == 0).sum() >= 1
+    is_one = (pvals == 1).sum() >= 1
+    if is_zero:
+        return 0
+    if is_one:
+        print('There are p-values exactly equal to 1!')
+        return min(1, min(pvals) * len(pvals))
+
+    # check the validity of weights (default: equal weights) and standardize them.
+    if weights is None:
+        weights = np.repeat(1/len(pvals), len(pvals))
+    elif len(weights) != len(pvals):
+        raise ValueError("The length of weights should be the same as that of the p-values!")
+    elif (weights < 0).sum() > 0:
+        raise ValueError("All the weights must be positive!")
+    else:
+        weights = weights / np.sum(weights)
+
+    # check if there are very small non-zero p-values
+    is_small = pvals < 1e-16
+    if is_small.sum() == 0:
+        cct_stat = np.sum(weights * np.tan((0.5 - pvals) * np.pi))
+    else:
+        cct_stat = np.sum((weights[is_small] / pvals[is_small]) / np.pi)
+        cct_stat += np.sum(weights[~is_small] * np.tan((0.5 - pvals[~is_small]) * np.pi))
+
+    # check if the test statistic is very large.
+    if cct_stat > 1e+15:
+        pval = (1 / cct_stat) / np.pi
+    else:
+        pval = 1 - cauchy.cdf(cct_stat)
+
+    return pval
+
+@click.option(
+    '--input-dir',
+    help='GCS path to the raw results of associaTR',
+    type=str,
+)
+@click.option(
+    '--cell-types',
+    help='Name of the cell type, comma separated if multiple',
+)
+@click.option(
+    '--chromosomes',
+    help='Chromosome number eg 1, comma separated if multiple',
+)
+@click.command()
+def main(input_dir, cell_types, chromosomes):
+    for cell_type in cell_types.split(','):
+        genes_pval_dict={}
+        for chromosome in chromosomes.split(','):
+            # read the raw results
+            raw_results = pd.read_csv(f"{input_dir}/{cell_type}/chr{chromosome}.assoc", sep='\t')
+            # compute gene-level p-values
+            gene_pvals = raw_results.groupby('gene')['pval'].apply(CCT)
+            # write the gene-level p-values to a file
+            gene_pvals.to_csv(f"{input_dir}/{cell_type}/chr{chromosome}_gene_pvals.tsv", sep='\t', header=False)
+

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -134,7 +134,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs):
             job.depends_on(_dependent_jobs[-max_parallel_jobs])
         _dependent_jobs.append(job)
 
-    genes_per_job = 50
+    genes_per_job = 100
 
     for cell_type in cell_types.split(','):
         for chromosome in chromosomes.split(','):

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# pylint: disable=too-many-arguments,too-many-locals
 
 """
 

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -134,7 +134,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs):
             job.depends_on(_dependent_jobs[-max_parallel_jobs])
         _dependent_jobs.append(job)
 
-    genes_per_job = 100
+    genes_per_job = 70
 
     for cell_type in cell_types.split(','):
         for chromosome in chromosomes.split(','):

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -5,6 +5,7 @@
 This script computes gene-level p-values using ACAT (the first step of multiple testing correction).
 Assumed input files follow the format of output TSV files from associaTR.
 Output is multiple gene-specific TSV files with the gene name in the first column, and gene-level p-value in the second column.
+The attributes of the locus with the lowest raw p-value are also stored in the TSV file (coordinates, beta, se, raw pval,r2, motif, ref_len).
 
 analysis-runner --dataset "bioheart" --description "compute gene level pvals" --access-level "test" \
     --output-dir "str/associatr/rna_pc_calibration/2_pcs/results" \
@@ -196,7 +197,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs):
                         r2 = []
                         motif = []
                         ref_len = []
-                        for index, row in min_rows.iterrows():
+                        for _index, row in min_rows.iterrows():
                             chr.append(row.iloc[0])
                             pos.append(row.iloc[1])
                             n_samples_tested.append(row.iloc[3])
@@ -231,4 +232,4 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs):
 
 
 if __name__ == '__main__':
-    main()  # pylint: disable=no-value-for-parameter
+    main()  # pylint: disable=no-value-for-parameter,too-many-arguments,too-many-locals,too-many-nested-blocks

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -134,7 +134,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs):
             job.depends_on(_dependent_jobs[-max_parallel_jobs])
         _dependent_jobs.append(job)
 
-    genes_per_job = 30
+    genes_per_job = 50
 
     for cell_type in cell_types.split(','):
         for chromosome in chromosomes.split(','):

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -134,7 +134,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs):
             job.depends_on(_dependent_jobs[-max_parallel_jobs])
         _dependent_jobs.append(job)
 
-    genes_per_job = 15
+    genes_per_job = 30
 
     for cell_type in cell_types.split(','):
         for chromosome in chromosomes.split(','):

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -37,6 +37,7 @@ def cct(
     r2,
     motif,
     ref_len,
+    allele_frequency,
     weights=None,
 ):
     """
@@ -112,10 +113,10 @@ def cct(
     )
     with to_path(gcs_output).open('w') as f:
         f.write(
-            f'gene_name\tgene_level_pval\tchr\tpos\tn_samples_tested\tlowest_raw_pval\tcoeff\tse\tr2\tmotif\tref_len\n'
+            f'gene_name\tgene_level_pval\tchr\tpos\tn_samples_tested\tlowest_raw_pval\tcoeff\tse\tr2\tmotif\tref_len\tallele_freq\n'
         )
         f.write(
-            f'{gene_name}\t{str(pval)}\t{str(chr)}\t{str(pos)}\t{str(n_samples_tested)}\t{str(raw_pval)}\t{str(coeff)}\t{str(se)}\t{str(r2)}\t{str(motif)}\t{str(ref_len)}\n'
+            f'{gene_name}\t{str(pval)}\t{str(chr)}\t{str(pos)}\t{str(n_samples_tested)}\t{str(raw_pval)}\t{str(coeff)}\t{str(se)}\t{str(r2)}\t{str(motif)}\t{str(ref_len)}\t{str(allele_frequency)}\n'
         )
 
 
@@ -186,7 +187,8 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs):
                         se = [min_rows.iloc[:, 7].values[0]]
                         r2 = [min_rows.iloc[:, 8].values[0]]
                         motif = [min_rows.iloc[:, 9].values[0]]
-                        ref_len = [min_rows.iloc[:, 10].values[0]]
+                        ref_len = [min_rows.iloc[:, 11].values[0]]
+                        allele_frequency = [min_rows.iloc[:, 12].values[0]]
                     else:
                         chr = []
                         pos = []
@@ -206,7 +208,8 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs):
                             se.append(row.iloc[7])
                             r2.append(row.iloc[8])
                             motif.append(row.iloc[9])
-                            ref_len.append(row.iloc[10])
+                            ref_len.append(row.iloc[11])
+                            allele_frequency.append(row.iloc[12])
 
                     pvals = np.array(pvals)
                     gene_name = gene_results.columns[5].split('_')[-1]
@@ -225,6 +228,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs):
                         r2,
                         motif,
                         ref_len,
+                        allele_frequency,
                     )
                 manage_concurrency_for_job(j)
 

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -9,7 +9,7 @@ Output is multiple gene-specific TSV files with the gene name in the first colum
 
 analysis-runner --dataset "bioheart" --description "compute gene level pvals" --access-level "test" \
     --output-dir "str/associatr/rna_pc_calibration/2_pcs/results" \
-    compute_gene_level_pvals.py --input-dir=gs://cpg-bioheart-test/str/associatr/rna_pc_calibration/2_pcs/results/v1 \
+    run_acat.py --input-dir=gs://cpg-bioheart-test/str/associatr/rna_pc_calibration/2_pcs/results/v1 \
     --cell-types=CD8_TEM --chromosomes=2
 
 """
@@ -44,9 +44,8 @@ def cct(gene_name, pvals, cell_type, chromosome, weights=None):
     R code is implemented in python
     """
 
-    # check if there is NA
-    if np.isnan(pvals).sum() > 0:
-        raise ValueError('Cannot have NAs in the p-values!')
+    # remove NA values - associaTR reports pval as NA if locus was thrown out (not tested)
+    pvals = pvals[~np.isnan(pvals)]
 
     # check if all p-values are between 0 and 1
     if ((pvals < 0).sum() + (pvals > 1).sum()) > 0:

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -33,7 +33,7 @@ def cct(gene_name, pvals, cell_type, chromosome, weights=None):
     #' between 0 to 1, to be combined.
     #' @param weights a numeric vector of non-negative weights. If code{NULL}, the
     #' equal weights are assumed.
-    #' @return the aggregated p-value combining p-values from the vector \code{pvals}.
+    #' @return the aggregated p-value combining p-values from the vector code{pvals}.
     #' @examples pvalues <- c(2e-02,4e-04,0.2,0.1,0.8)
     #' @examples CCT(pvals=pvalues)
     #' @references Liu, Y., & Xie, J. (2020). Cauchy combination test: a powerful test

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -116,7 +116,7 @@ def cct(gene_name, pvals, cell_type, chromosome, weights=None):
 @click.option(
     '--max-parallel-jobs',
     type=int,
-    default=50,
+    default=500,
     help=('To avoid exceeding Google Cloud quotas, set this concurrency as a limit.'),
 )
 @click.command()
@@ -149,6 +149,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs):
                 j = get_batch('Compute gene level pvals').new_python_job(
                     name=f'Compute gene-level p-values for {gene_name}'
                 )
+                j.cpu(0.25).memory('lowmem')
                 j.call(cct, gene_name, pvals, cell_type, chromosome)
                 manage_concurrency_for_job(j)
 

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -92,7 +92,6 @@ def CCT(pvals, weights=None):
 @click.command()
 def main(input_dir, cell_types, chromosomes):
     for cell_type in cell_types.split(','):
-        genes_pval_dict={}
         for chromosome in chromosomes.split(','):
             # read the raw results
             raw_results = pd.read_csv(f"{input_dir}/{cell_type}/chr{chromosome}.assoc", sep='\t')

--- a/str/associatr/run_acat.py
+++ b/str/associatr/run_acat.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+# pylint: disable=no-value-for-parameter,too-many-arguments,too-many-locals,too-many-nested-blocks
 """
 
 This script computes gene-level p-values using ACAT (the first step of multiple testing correction).


### PR DESCRIPTION
This script computes gene-level p-values using either ACAT/Bonferroni (the first step of multiple testing correction).
Assumed input files follow the format of output TSV files from associaTR.
Output is multiple gene-specific TSV files with the gene name in the first column, and gene-level p-value in the second column.The attributes of the locus with the lowest raw p-value are also stored in the TSV file (coordinates, beta, se, raw pval,r2, motif, ref_len).

Runs ok https://batch.hail.populationgenomics.org.au/batches/437270
