### PR TITLE
Update get_covariates to select geno PCs 1 and 6 only 

### DIFF
--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -24,11 +24,7 @@ from cpg_utils import to_path
 
 
 def get_covariates(
-    pseudobulk_input_dir,
-    cell_type,
-    chromosomes,
-    covariate_file_path,
-    num_pcs,
+    pseudobulk_input_dir, cell_type, chromosomes, covariate_file_path, num_pcs
 ):
     """
     Calculates cell-type specific PCs from the pseudobulk data (genome-wide),
@@ -69,13 +65,11 @@ def get_covariates(
     # extract PCs
     df_pcs = pd.DataFrame(adata_genome.obsm['X_pca'])
     df_pcs.index = adata_genome.obs.index
-    df_pcs = df_pcs.rename_axis(
-        'sample_id'
-    ).reset_index()  # index (CPG ids) are not stored in 'sample_id' column
+    # index (CPG ids) are not stored in 'sample_id' column
+    df_pcs = df_pcs.rename_axis('sample_id').reset_index()
     df_pcs = df_pcs[['sample_id'] + list(range(num_pcs))]
-    df_pcs = df_pcs.rename(
-        columns={i: f'rna_PC{i+1}' for i in range(num_pcs)}
-    )  # rename PC columns: rna_PC{num}
+    # rename PC columns: rna_PC{num}
+    df_pcs = df_pcs.rename(columns={i: f'rna_PC{i+1}' for i in range(num_pcs)})
 
     # read in covariates
     cov = pd.read_csv(covariate_file_path)
@@ -83,7 +77,11 @@ def get_covariates(
     cov = cov[['sample_id', 'sex', 'age', 'geno_PC1', 'geno_PC6']]
 
     # cut-offs for geno PCs (filter out ancestry outliers)
-    cov = cov[(cov['geno_PC1'] >= -0.05) & (cov['geno_PC6'] <= 0.05) &(cov['geno_PC6'] >= -0.05) ]
+    cov = cov[
+        (cov['geno_PC1'] >= -0.05)
+        & (cov['geno_PC6'] <= 0.05)
+        & (cov['geno_PC6'] >= -0.05)
+    ]
 
     merged_df = pd.merge(cov, df_pcs, on='sample_id')
 
@@ -94,7 +92,6 @@ def get_covariates(
     )
 
 
-# inputs:
 @click.option(
     '--input-dir', help='GCS Path to the input dir storing pseudobulk CSV files'
 )
@@ -120,7 +117,6 @@ def main(
 ):
     """
     Obtain cell-type specific covariates for pseudobulk associaTR model
-
     """
     b = get_batch(name=f'Get covariates for {cell_types}')
 

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -4,6 +4,7 @@ This script calculates cell-type specific PCs from the pseudobulk RNA data (geno
 merges them with other pre-calculated covariates, and writes the file to GCP.
 
 We include only genotype PC 1 and 6 as covariates and apply thresholds to remove ancestry outliers.
+Thresholds are a temporary solution, awaiting finalization of ancestry results from the LC pipeline.
 
 analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
 --description "Get covariates" --output-dir "str/associatr/input_files/240_libraries_tenk10kp1_v2" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/input_files/240_libraries_tenk10kp1_v2/pseudobulk \
@@ -121,7 +122,7 @@ def main(
     Obtain cell-type specific covariates for pseudobulk associaTR model
 
     """
-    b = get_batch(name = f'Get covariates for {cell_types}')
+    b = get_batch(name=f'Get covariates for {cell_types}')
 
     logging.info(f'Cell types to run: {cell_types}')
     logging.info(f'Chromosomes to run: {chromosomes}')

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -3,13 +3,11 @@
 This script calculates cell-type specific PCs from the pseudobulk RNA data (genome-wide),
 merges them with other pre-calculated covariates, and writes the file to GCP.
 
-We include only genotype PC 1 and 6 as covariates and apply thresholds to remove ancestry outliers.
-Thresholds are a temporary solution, awaiting finalization of ancestry results from the LC pipeline.
 
 analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
---description "Get covariates" --output-dir "str/associatr/input_files/240_libraries_tenk10kp1_v2" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/input_files/240_libraries_tenk10kp1_v2/pseudobulk \
---cell-types=CD4_TCM --chromosomes=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 --covariate-file-path=gs://cpg-bioheart-test/str/anndata/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv \
---num-pcs=7
+--description "Get covariates" --output-dir "str/associatr/tob_n1055/input_files" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/tob_n1055/input_files/pseudobulk \
+--cell-types=CD4_TCM --chromosomes=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 --covariate-file-path=gs://gs://cpg-bioheart-test/str/associatr/tob_n1055/input_files/tob_covariates_str_run_v1.csv \
+--num-pcs=20
 
 """
 
@@ -73,15 +71,6 @@ def get_covariates(
 
     # read in covariates
     cov = pd.read_csv(covariate_file_path)
-
-    cov = cov[['sample_id', 'sex', 'age', 'geno_PC1', 'geno_PC6']]
-
-    # cut-offs for geno PCs (filter out ancestry outliers)
-    cov = cov[
-        (cov['geno_PC1'] >= -0.05)
-        & (cov['geno_PC6'] <= 0.05)
-        & (cov['geno_PC6'] >= -0.05)
-    ]
 
     merged_df = pd.merge(cov, df_pcs, on='sample_id')
 

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -3,6 +3,8 @@
 This script calculates cell-type specific PCs from the pseudobulk RNA data (genome-wide),
 merges them with other pre-calculated covariates, and writes the file to GCP.
 
+We include only genotype PC 1 and 6 as covariates and apply thresholds to remove ancestry outliers.
+
 analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
 --description "Get covariates" --output-dir "str/associatr/input_files/240_libraries_tenk10kp1_v2" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/input_files/240_libraries_tenk10kp1_v2/pseudobulk \
 --cell-types=CD4_TCM --chromosomes=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 --covariate-file-path=gs://cpg-bioheart-test/str/anndata/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv \
@@ -119,7 +121,7 @@ def main(
     Obtain cell-type specific covariates for pseudobulk associaTR model
 
     """
-    b = get_batch()
+    b = get_batch(name = f'Get covariates for {cell_types}')
 
     logging.info(f'Cell types to run: {cell_types}')
     logging.info(f'Chromosomes to run: {chromosomes}')

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -4,9 +4,9 @@ This script calculates cell-type specific PCs from the pseudobulk RNA data (geno
 merges them with other pre-calculated covariates, and writes the file to GCP.
 
 analysis-runner --access-level test --dataset bioheart --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
---description "Get covariates" --output-dir "str/associatr/rna_pc_calibration/24_pcs/input_files" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/input_files/pseudobulk/remapped_ids \
---cell-types=CD8_TEM --chromosomes=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 --covariate-file-path=gs://cpg-bioheart-test/str/anndata/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv \
---num-pcs=24
+--description "Get covariates" --output-dir "str/associatr/input_files/240_libraries_tenk10kp1_v2" get_covariates.py --input-dir=gs://cpg-bioheart-test/str/associatr/input_files/240_libraries_tenk10kp1_v2/pseudobulk \
+--cell-types=CD4_TCM --chromosomes=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 --covariate-file-path=gs://cpg-bioheart-test/str/anndata/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv \
+--num-pcs=7
 
 """
 

--- a/str/associatr/get_covariates.py
+++ b/str/associatr/get_covariates.py
@@ -83,7 +83,7 @@ def get_covariates(
     cov = cov[['sample_id', 'sex', 'age', 'geno_PC1', 'geno_PC6']]
 
     # cut-offs for geno PCs (filter out ancestry outliers)
-    cov = cov[(cov['geno_PC1'] >= -0.1) & (cov['geno_PC6'] <= 0.15)]
+    cov = cov[(cov['geno_PC1'] >= -0.05) & (cov['geno_PC6'] <= 0.05) &(cov['geno_PC6'] >= -0.05) ]
 
     merged_df = pd.merge(cov, df_pcs, on='sample_id')
 

--- a/str/inputs/pure_repeats_catalog/Bed_to_fasta__2/bed_to_fasta.py
+++ b/str/inputs/pure_repeats_catalog/Bed_to_fasta__2/bed_to_fasta.py
@@ -4,8 +4,7 @@
 Converts coordinates in BED file to FASTA sequence
 """
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import output_path
-from cpg_workflows.batch import get_batch
+from cpg_utils.hail_batch import get_batch, output_path
 
 
 CATALOG_PATH = (


### PR DESCRIPTION
See discussion here: https://centrepopgen.slack.com/archives/C063WDT5HT4/p1711155305004049

We amend the script to only genotype PC 1 and 6 as covariates and apply thresholds to these two PCs to remove ancestry outliers; temporary solution until LC pipeline ancestry results are finalised
