### PR TITLE
Copy cohort specific MTs into test bucket

### DIFF
--- a/str/helper/cp_mt.sh
+++ b/str/helper/cp_mt.sh
@@ -4,4 +4,9 @@
 
 set -ex
 
-gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n2045/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n2045/mt/v1/str.mt
+#gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n2045/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n2045/mt/v1/str.mt
+
+# copy cohort specific mts (changing approach to analyse each cohort separately because of distinct batch effects) 
+
+gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt
+gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt

--- a/str/helper/cp_mt.sh
+++ b/str/helper/cp_mt.sh
@@ -10,3 +10,4 @@ set -ex
 
 gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt
 gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt
+

--- a/str/helper/cp_mt.sh
+++ b/str/helper/cp_mt.sh
@@ -9,4 +9,4 @@ set -ex
 # copy cohort specific mts (changing approach to analyse each cohort separately because of distinct batch effects)
 
 gcloud storage cp -r gs://cpg-bioheart-main/str/polymorphic_run_n990_bioheart_only/annotated_mt/v1/str_annotated.mt gs://cpg-bioheart-test/str/polymorphic_run_n990_bioheart_only/annotated_mt/v1/str_annotated.mt
-gcloud storage cp -r gs://cpg-bioheart-main/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt
+gcloud storage cp -r gs://cpg-bioheart-main/str/polymorphic_run_n1055_tob_only/annotated_mt/v1/str_annotated.mt gs://cpg-bioheart-test/str/polymorphic_run_n1055_tob_only/annotated_mt/v1/str_annotated.mt

--- a/str/helper/cp_mt.sh
+++ b/str/helper/cp_mt.sh
@@ -8,5 +8,5 @@ set -ex
 
 # copy cohort specific mts (changing approach to analyse each cohort separately because of distinct batch effects)
 
-gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt
-gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt
+gcloud storage cp -r gs://cpg-bioheart-main/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt
+gcloud storage cp -r gs://cpg-bioheart-main/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt

--- a/str/helper/cp_mt.sh
+++ b/str/helper/cp_mt.sh
@@ -8,5 +8,5 @@ set -ex
 
 # copy cohort specific mts (changing approach to analyse each cohort separately because of distinct batch effects)
 
-gcloud storage cp -r gs://cpg-bioheart-main/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt
+gcloud storage cp -r gs://cpg-bioheart-main/str/polymorphic_run_n990_bioheart_only/annotated_mt/v1/str_annotated.mt gs://cpg-bioheart-test/str/polymorphic_run_n990_bioheart_only/annotated_mt/v1/str_annotated.mt
 gcloud storage cp -r gs://cpg-bioheart-main/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt

--- a/str/helper/cp_mt.sh
+++ b/str/helper/cp_mt.sh
@@ -6,7 +6,7 @@ set -ex
 
 #gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n2045/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n2045/mt/v1/str.mt
 
-# copy cohort specific mts (changing approach to analyse each cohort separately because of distinct batch effects) 
+# copy cohort specific mts (changing approach to analyse each cohort separately because of distinct batch effects)
 
 gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt
 gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt

--- a/str/helper/cp_mt.sh
+++ b/str/helper/cp_mt.sh
@@ -10,4 +10,3 @@ set -ex
 
 gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n990_bioheart_only/mt/v1/str.mt
 gsutil -m cp -r gs://cpg-bioheart-main/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt gs://cpg-bioheart-test/str/polymorphic_run_n1055_tob_only/mt/v1/str.mt
-


### PR DESCRIPTION
New strategy to analyse the cohorts separately (quick iterative QC in `test`) due to complex batch effects. 

See earlier PR copying over a joint MT of both datasets here: https://github.com/populationgenomics/sv-workflows/pull/153#issue-2145686243

This is an exception and applied for the purposes of quick iterative QC. Final QC scripts will still be merged into `main`, with final QC plots also produced in respective `main-analysis` buckets. At this point, I will delete the mt from `test`