### PR TITLE
Remove cohort covariate from cis numpy creation

### DIFF
--- a/str/associatr/get_cis_numpy_files.py
+++ b/str/associatr/get_cis_numpy_files.py
@@ -10,7 +10,7 @@ This script aims to:
  - output gene-level phenotype and covariate numpy objects for input into associatr
 
  analysis-runner  --config get_cis_numpy_files.toml --dataset "bioheart" --access-level "test" \
---description "get cis and numpy" --output-dir "str/associatr/rna_pc_calibration/2_pcs/input_files"  \
+--description "get cis and numpy" --output-dir "str/associatr/tob_n1055/input_files"  \
 --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
 python3 get_cis_numpy_files.py
 
@@ -108,7 +108,6 @@ def cis_window_numpy_extractor(
 
         # filter for samples that were assigned a CPG ID; unassigned samples after demultiplexing will not have a CPG ID
         gene_pheno_cov = gene_pheno_cov[gene_pheno_cov['sample_id'].str.startswith('CPG')]
-
 
         gene_pheno_cov['sample_id'] = gene_pheno_cov['sample_id'].str[
             3:

--- a/str/associatr/get_cis_numpy_files.py
+++ b/str/associatr/get_cis_numpy_files.py
@@ -109,14 +109,6 @@ def cis_window_numpy_extractor(
         # filter for samples that were assigned a CPG ID; unassigned samples after demultiplexing will not have a CPG ID
         gene_pheno_cov = gene_pheno_cov[gene_pheno_cov['sample_id'].str.startswith('CPG')]
 
-        # add in cohort as a covariate
-        cohort_cpg_id = adata.obs[['cpg_id', 'cohort']]
-        mapping = {'TOB': 1, 'BioHEART': 2}
-        cohort_cpg_id['cohort'] = cohort_cpg_id['cohort'].map(mapping)
-        cohort_cpg_id.rename(columns={'cpg_id': 'sample_id'}, inplace=True)  # noqa: PD002
-        cohort_cpg_id = cohort_cpg_id.drop_duplicates()
-
-        gene_pheno_cov = gene_pheno_cov.merge(cohort_cpg_id, on='sample_id', how='inner')
 
         gene_pheno_cov['sample_id'] = gene_pheno_cov['sample_id'].str[
             3:

--- a/str/associatr/get_cis_numpy_files.toml
+++ b/str/associatr/get_cis_numpy_files.toml
@@ -1,12 +1,12 @@
 [get_cis_numpy]
 # GCS directory to the input AnnData objects
-input_h5ad_dir = 'gs://cpg-bioheart-test/str/anndata-240/cpg_anndata/cpg_anndata'
+input_h5ad_dir = 'gs://cpg-bioheart-test/str/240_libraries_tenk10kp1_v2/cpg_anndata'
 # GCS directory to the input pseudobulk CSV files
-input_pseudobulk_dir = 'gs://cpg-bioheart-test/str/associatr/input_files/pseudobulk'
+input_pseudobulk_dir = 'gs://cpg-bioheart-test/str/associatr/tob_n1055/input_files/pseudobulk'
 # GCS directory to the input covariate CSV files
-input_cov_dir = 'gs://cpg-bioheart-test/str/associatr/rna_pc_calibration/5_pcs/input_files/covariates/5_rna_pcs'
+input_cov_dir = 'gs://cpg-bioheart-test/str/associatr/tob_n1055/input_files/covariates/7_rna_pcs'
 chromosomes = 'chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22'
-cell_types = 'CD8_TEM'
+cell_types = 'gdT,B_intermediate,ILC,Plasmablast,dnT,ASDC,cDC1,pDC,NK_CD56bright,MAIT,B_memory,CD4_CTL,CD4_Proliferating,CD8_Proliferating,HSPC,NK_Proliferating,cDC2,CD16_Mono,Treg,CD14_Mono,CD8_TCM,CD4_TEM,CD8_Naive,CD4_TCM,NK,CD8_TEM,CD4_Naive,B_naive'
 # cis window size in bp
 cis_window = 100000
 version = 'v1'


### PR DESCRIPTION
Cohort covariate no longer needed because we're not doing a joint analysis together anymore