### PR TITLE
Get gene level pval fix mw

### DIFF
--- a/str/associatr/multiple_testing_correction/run_gene_level_pval.py
+++ b/str/associatr/multiple_testing_correction/run_gene_level_pval.py
@@ -253,7 +253,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs, acat, bonferroni
 
                 if acat:
                     j = b.new_python_job(
-                        name=f'Compute gene-level p-values for genes {i+1}-{i+genes_per_job}',
+                        name=f'Compute gene-level p-values for genes {i+1}-{i+genes_per_job} in {cell_type}:{chromosome}',
                     )
                     j.cpu(0.25).memory('lowmem')
                     j.call(cct, batch_gene_files, cell_type, chromosome)
@@ -261,7 +261,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs, acat, bonferroni
 
                 if bonferroni:
                     f = b.new_python_job(
-                        name=f'Compute gene-level Bonferroni p-values for genes {i+1}-{i+genes_per_job}',
+                        name=f'Compute gene-level Bonferroni p-values for genes {i+1}-{i+genes_per_job} in {cell_type}:{chromosome}',
                     )
                     f.cpu(0.25).memory('lowmem')
                     f.call(bonferroni_compute, batch_gene_files, cell_type, chromosome)

--- a/str/associatr/multiple_testing_correction/run_gene_level_pval.py
+++ b/str/associatr/multiple_testing_correction/run_gene_level_pval.py
@@ -81,7 +81,7 @@ def cct(gene_files: list[str], cell_type: str, chromosome: str, og_weights=None)
     from scipy.stats import cauchy  # noqa: PLC0415
 
     from cpg_utils import to_path
-    from cpg_utils.hail_batch import output_path
+    from cpg_utils.config import output_path
 
     for gene_file in gene_files:
         weights = deepcopy(og_weights)
@@ -168,7 +168,7 @@ def bonferroni_compute(gene_files, cell_type, chromosome):
     import pandas as pd
 
     from cpg_utils import to_path
-    from cpg_utils.hail_batch import output_path
+    from cpg_utils.config import output_path
 
     for gene_file in gene_files:
         # read the raw results

--- a/str/associatr/multiple_testing_correction/run_gene_level_pval.py
+++ b/str/associatr/multiple_testing_correction/run_gene_level_pval.py
@@ -238,7 +238,7 @@ def main(input_dir, cell_types, chromosomes, max_parallel_jobs, acat, bonferroni
 
         for chromosome in chromosomes.split(','):
 
-            gene_files = list(to_path(f'{input_dir}/{cell_type}/chr{chromosome}').glob('*.tsv'))
+            gene_files = list(map(str, to_path(f'{input_dir}/{cell_type}/chr{chromosome}').glob('*.tsv')))
 
             # split the list of files into chunks
             for i in range(0, len(gene_files), genes_per_job):


### PR DESCRIPTION
Previous design: 

- All the gene files were opened, read, and partially processed in the driver job
- Only minimal further processing was done downstream in job images, so not making good use of parallelisation

Changes:

- Generates one batch per cell type, which should hugely help parallelisation
- Batch and list of jobs to manage concurrency for are reset between batches, so parallelisation should be hugely improved
- Passes lists of files to process into the batch jobs, where they are read and processed in full once the parallelisation hits, rather than reading thousands of files in the driver job
- only makes bonferroni/ccct jobs if that mode is selected, so as not to create dangling jobs with no commands executed in them