### PR TITLE
Script for Comparing Subsetted and Original VDS

### DIFF
--- a/str/helper/vds_checker.py
+++ b/str/helper/vds_checker.py
@@ -44,6 +44,8 @@ def main(tenk10k_filepath, bioheart_filepath):
     print(f' VDS variant data dimensions: {bioheart_variant_data_mt.count()}')
 
     bioheart_only_sgids = bioheart_vds.variant_data.s.collect()
+    # randomly sample 15 IDs
+    bioheart_sampled_ids = random.sample(bioheart_only_sgids, k=num_samples)
     # filter to just test subset
     filtered_tenk10k_vds = hl.vds.filter_samples(tenk10k_vds, bioheart_only_sgids)
 

--- a/str/helper/vds_checker.py
+++ b/str/helper/vds_checker.py
@@ -57,7 +57,7 @@ def main(tenk10k_filepath, bioheart_filepath):
     print(f'Variant data VDS same? {filtered_tenk10k_vds.variant_data._same(bioheart_vds.variant_data)}')
 
     # compare dense_mt's
-    print(filtered_tenk10k_dense._same(bioheart_dense))
+    print(f'Dense Matrix Tables same? {filtered_tenk10k_dense._same(bioheart_dense)}')
 
 
 if __name__ == '__main__':

--- a/str/helper/vds_checker.py
+++ b/str/helper/vds_checker.py
@@ -24,6 +24,11 @@ from cpg_utils.hail_batch import init_batch
     '--bioheart-filepath',
     help='GCS file path to VDS.',
 )
+@click.option(
+    '--num-samples',
+    help='Number of samples randomly selected to compare ',
+    default=15
+)
 @click.command()
 def main(tenk10k_filepath, bioheart_filepath):
     """Check if subsetting VDS is the same as producing VDS from scratch using only subsetted samples"""

--- a/str/helper/vds_checker.py
+++ b/str/helper/vds_checker.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+This Hail Query script prints the dimensions of a VDS
+ analysis-runner --dataset "bioheart" \
+    --description "mt_extractor" \
+    --access-level "test" \
+    --output-dir "str/polymorphic_run/mt/v1" \
+    vds_counter.py --file-path=gs://cpg-bioheart-test/vds/bioheart1-0.vds
+
+"""
+
+import click
+
+import hail as hl
+
+from cpg_utils.hail_batch import init_batch
+
+
+@click.option(
+    '--tenk10k-filepath',
+    help='GCS file path to VDS.',
+)
+@click.option(
+    '--bioheart-filepath',
+    help='GCS file path to VDS.',
+)
+@click.command()
+def main(tenk10k_filepath, bioheart_filepath):
+    """Check if subsetting VDS is the same as producing VDS from scratch using only subsetted samples"""
+
+    init_batch(worker_memory='highmem')
+
+    tenk10k_vds = hl.vds.read_vds(tenk10k_filepath)
+    bioheart_vds = hl.vds.read_vds(bioheart_filepath)
+
+    tenk10k_reference_data_mt = tenk10k_vds.reference_data
+    bioheart_reference_data_mt = bioheart_vds.reference_data
+    print(f' VDS reference data dimensions: {tenk10k_reference_data_mt.count()}')
+    print(f' VDS reference data dimensions: {bioheart_reference_data_mt.count()}')
+
+    tenk10k_variant_data_mt = tenk10k_vds.variant_data
+    bioheart_variant_data_mt = bioheart_vds.variant_data
+    print(f' VDS variant data dimensions: {tenk10k_variant_data_mt.count()}')
+    print(f' VDS variant data dimensions: {bioheart_variant_data_mt.count()}')
+
+    bioheart_only_sgids = bioheart_vds.variant_data.s.collect()
+    # filter to just test subset
+    filtered_tenk10k_vds = hl.vds.filter_samples(tenk10k_vds, bioheart_only_sgids)
+
+    # densify both
+    filtered_tenk10k_dense = hl.vds.to_dense_mt(filtered_tenk10k_vds)
+    bioheart_dense = hl.vds.to_dense_mt(bioheart_vds)
+    print(f' Filtered tenk10K dense_mt data dimensions: {filtered_tenk10k_dense.count()}')
+    print(f' BioHEART dense_mt data dimensions: {bioheart_dense.count()}')
+
+    # compare vds represenations
+    print(filtered_tenk10k_vds.variant_data._same(bioheart_vds.variant_data))
+
+    # compare dense_mt's
+    print(filtered_tenk10k_dense._same(bioheart_dense))
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/str/helper/vds_checker.py
+++ b/str/helper/vds_checker.py
@@ -57,7 +57,7 @@ def main(tenk10k_filepath, bioheart_filepath, num_samples):
 
     # densify both
     filtered_tenk10k_dense = hl.vds.to_dense_mt(filtered_tenk10k_vds)
-    bioheart_dense = hl.vds.to_dense_mt(bioheart_vds)
+    bioheart_dense = hl.vds.to_dense_mt(filtered_bioheart_vds)
     print(f' Filtered tenk10K dense_mt data dimensions: {filtered_tenk10k_dense.count()}')
     print(f' BioHEART dense_mt data dimensions: {bioheart_dense.count()}')
 

--- a/str/helper/vds_checker.py
+++ b/str/helper/vds_checker.py
@@ -54,7 +54,7 @@ def main(tenk10k_filepath, bioheart_filepath):
     print(f' BioHEART dense_mt data dimensions: {bioheart_dense.count()}')
 
     # compare vds represenations
-    print(filtered_tenk10k_vds.variant_data._same(bioheart_vds.variant_data))
+    print(f'Variant data VDS same? {filtered_tenk10k_vds.variant_data._same(bioheart_vds.variant_data)}')
 
     # compare dense_mt's
     print(filtered_tenk10k_dense._same(bioheart_dense))

--- a/str/helper/vds_checker.py
+++ b/str/helper/vds_checker.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """
-This Hail Query script prints the dimensions of a VDS
+This Hail Query script checks subsetting consistency between multi-cohort VDS and single-cohort VDS.
  analysis-runner --dataset "bioheart" \
     --description "mt_extractor" \
-    --access-level "test" \
-    --output-dir "str/polymorphic_run/mt/v1" \
-    vds_counter.py --file-path=gs://cpg-bioheart-test/vds/bioheart1-0.vds
+    --access-level "full" \
+    --output-dir "str/" \
+    vds_checker.py --tenk10k-filepath=gs://cpg-bioheart-main/vds/tenk10k1-0.vds --bioheart-filepath=gs://cpg-bioheart-main/vds/bioheart1-0.vds
 
 """
 

--- a/str/helper/vds_checker.py
+++ b/str/helper/vds_checker.py
@@ -47,7 +47,8 @@ def main(tenk10k_filepath, bioheart_filepath):
     # randomly sample 15 IDs
     bioheart_sampled_ids = random.sample(bioheart_only_sgids, k=num_samples)
     # filter to just test subset
-    filtered_tenk10k_vds = hl.vds.filter_samples(tenk10k_vds, bioheart_only_sgids)
+    filtered_tenk10k_vds = hl.vds.filter_samples(tenk10k_vds, bioheart_sampled_ids)
+    filtered_bioheart_vds = hl.vds.filter_samples(bioheart_vds, bioheart_sampled_ids)
 
     # densify both
     filtered_tenk10k_dense = hl.vds.to_dense_mt(filtered_tenk10k_vds)

--- a/str/helper/vds_checker.py
+++ b/str/helper/vds_checker.py
@@ -30,7 +30,7 @@ from cpg_utils.hail_batch import init_batch
     default=15
 )
 @click.command()
-def main(tenk10k_filepath, bioheart_filepath):
+def main(tenk10k_filepath, bioheart_filepath, num_samples):
     """Check if subsetting VDS is the same as producing VDS from scratch using only subsetted samples"""
 
     init_batch(worker_memory='highmem')

--- a/str/helper/vds_checker.py
+++ b/str/helper/vds_checker.py
@@ -5,12 +5,14 @@ This Hail Query script checks subsetting consistency between multi-cohort VDS an
     --description "mt_extractor" \
     --access-level "full" \
     --output-dir "str/" \
-    vds_checker.py --tenk10k-filepath=gs://cpg-bioheart-main/vds/tenk10k1-0.vds --bioheart-filepath=gs://cpg-bioheart-main/vds/bioheart1-0.vds
+    vds_checker.py --tenk10k-filepath=gs://cpg-bioheart-main/vds/tenk10k1-0.vds --bioheart-filepath=gs://cpg-bioheart-main/vds/bioheart1-0.vds --num-samples=15
 
 """
 
-import click
 import random
+
+import click
+
 import hail as hl
 
 from cpg_utils.hail_batch import init_batch
@@ -27,7 +29,7 @@ from cpg_utils.hail_batch import init_batch
 @click.option(
     '--num-samples',
     help='Number of samples randomly selected to compare ',
-    default=15
+    default=15,
 )
 @click.command()
 def main(tenk10k_filepath, bioheart_filepath, num_samples):

--- a/str/helper/vds_checker.py
+++ b/str/helper/vds_checker.py
@@ -10,7 +10,7 @@ This Hail Query script checks subsetting consistency between multi-cohort VDS an
 """
 
 import click
-
+import random
 import hail as hl
 
 from cpg_utils.hail_batch import init_batch


### PR DESCRIPTION
Compare a multi-cohort VDS (tenk10k vds) with a single-cohort VDS (Bioheart vds). The purpose of this comparison is to verify if subsetting the combined VDS to just bioheart samples produces the same result as if creating a bioheart-only VDS from scratch.

The script performs the following steps:

Reads in the tenk10k and bioheart VDS files.
Prints the dimensions of the reference and variant data for both VDS files.
Collects the sample IDs from the bioheart VDS and uses them to filter the tenk10k VDS.
Converts both the filtered tenk10k VDS and the original bioheart VDS to dense matrix tables.
Prints the dimensions of the dense matrix tables.
Compares the variant data of the filtered tenk10k VDS and the original bioheart VDS.
Compares the dense matrix tables of the filtered tenk10k VDS and the original bioheart VDS.