### PR TITLE
Calculate LD between one STR locus and all SNPs in a colocalised locus. 

### DIFF
--- a/str/coloc/ld_parser.py
+++ b/str/coloc/ld_parser.py
@@ -205,7 +205,7 @@ def main(
                 chr_num = '22'
                 print(f'Running LD for {gene} and {str_locus}')
                 gwas_snp_path = f'{coloc_dir}/{phenotype}/{celltype}/{gene}_snp_gwas_list.csv'
-                snp_vcf_path = f'{snp_vcf_dir}/chr{chr_num}_common_variants_renamed.vcf.bgz'
+                snp_vcf_path = f'{snp_vcf_dir}/chr{chr}_common_variants_renamed.vcf.bgz'
                 str_vcf_path = f'{str_vcf_dir}/hail_filtered_chr{chr_num}.vcf.bgz'
                 # run coloc
                 b = get_batch()

--- a/str/coloc/ld_parser.py
+++ b/str/coloc/ld_parser.py
@@ -35,12 +35,18 @@ import ast
 import click
 import pandas as pd
 
-from cpg_utils.hail_batch import get_batch
 from cpg_utils.config import output_path
+from cpg_utils.hail_batch import get_batch
 
 
 def ld_parser(
-    snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str, output_path: str, gwas_snp_path: str, gene: str,
+    snp_vcf_path: str,
+    str_vcf_path: str,
+    str_locus: str,
+    window: str,
+    output_path: str,
+    gwas_snp_path: str,
+    gene: str,
 ):
     import pandas as pd
     from cyvcf2 import VCF
@@ -117,7 +123,7 @@ def ld_parser(
 
     # find the SNP with the highest absolute correlation
     max_correlation_index = correlation_df['correlation'].abs().idxmax()
-    max_correlation_df = correlation_df[correlation_df['locus'] ==max_correlation_index]
+    max_correlation_df = correlation_df[correlation_df['locus'] == max_correlation_index]
 
     # add some attributes
     max_correlation_df['gene'] = gene
@@ -136,7 +142,6 @@ def ld_parser(
     help='GCS file dir to STR VCF files.',
     type=str,
 )
-
 @click.option('--coloc-dir', help='GCS file path to coloc results', type=str)
 @click.option('--phenotype', help='Phenotype to use for coloc', type=str)
 @click.option('--celltypes', help='Cell types to use for coloc', type=str)
@@ -172,9 +177,9 @@ def main(
         coloc_results = coloc_results[coloc_results['PP.H4.abf'] >= 0.5]
 
         # obtain inputs for LD parsing for each entry in `coloc_results`:
-        #for index, row in coloc_results.iterrows():
-        for gene in ['ENSG00000196421']:# for testing
-            #gene = row['gene']
+        # for index, row in coloc_results.iterrows():
+        for gene in ['ENSG00000196421']:  # for testing
+            # gene = row['gene']
             # obtain snp cis-window coordinates for the gene
             gene_annotation_table = pd.read_csv(gene_annotation_file)
             gene_table = gene_annotation_table[
@@ -186,15 +191,16 @@ def main(
             snp_window = f'{chr}:{start_snp_window}-{end_snp_window}'
             print('Obtained SNP window coordinates')
 
-
             # obtain top STR locus for the gene
             str_fdr_gene = str_fdr[str_fdr['gene_name'] == gene]
-            for estr in zip(ast.literal_eval(str_fdr_gene['chr'].iloc[0]), ast.literal_eval(str_fdr_gene['pos'].iloc[0])):
+            for estr in zip(
+                ast.literal_eval(str_fdr_gene['chr'].iloc[0]), ast.literal_eval(str_fdr_gene['pos'].iloc[0]),
+            ):
                 chr_num = estr[0][3:]
                 pos = estr[1]
                 end = str(int(pos) + 1)
                 str_locus = f'{chr_num}:{pos}-{end}'
-                #for testing only
+                # for testing only
                 str_locus = '22:10515024-10515025'
                 chr_num = '22'
                 print(f'Running LD for {gene} and {str_locus}')
@@ -207,13 +213,14 @@ def main(
                     f'LD calc for {gene} and STR: {str_locus}; {celltype}',
                 )
                 ld_job(
-                ld_parser,
+                    ld_parser,
                     snp_vcf_path,
                     str_vcf_path,
                     str_locus,
                     snp_window,
                     output_path(
-                        f'coloc_str_ld/{phenotype}/{celltype}/{gene}_chr{chr_num}_{pos}_ld_results.csv', 'analysis',
+                        f'coloc_str_ld/{phenotype}/{celltype}/{gene}_chr{chr_num}_{pos}_ld_results.csv',
+                        'analysis',
                     ),
                     gwas_snp_path,
                     gene,

--- a/str/coloc/ld_parser.py
+++ b/str/coloc/ld_parser.py
@@ -212,8 +212,7 @@ def main(
                 ld_job = b.new_python_job(
                     f'LD calc for {gene} and STR: {str_locus}; {celltype}',
                 )
-                ld_job(
-                    ld_parser,
+                ld_job.call(ld_parser,
                     snp_vcf_path,
                     str_vcf_path,
                     str_locus,

--- a/str/coloc/ld_parser.py
+++ b/str/coloc/ld_parser.py
@@ -224,6 +224,7 @@ def main(
                     gwas_snp_path,
                     gene,
                 )
+            b.run(wait=False)
 
 
 if __name__ == '__main__':

--- a/str/coloc/ld_parser.py
+++ b/str/coloc/ld_parser.py
@@ -7,13 +7,13 @@ Outputs the locus-level LD results as a TSV file.
 
 analysis-runner --dataset "bioheart" \
     --description "Calculate LD between STR and SNPs" \
-    --access-level "full" \
+    --access-level "test" \
     --cpu=4 \
     --output-dir "str/ld/test-run" \
-    ld_parser.py --snp-vcf-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/genotypes/vds-bioheart1-0/chr20_common_variants.vcf.bgz \
+    ld_parser.py --snp-vcf-path=gs://cpg-bioheart-test/str/dummy_snp_vcf/chr20_common_variants_renamed.vcf.bgz \
     --str-vcf-path=gs://cpg-bioheart-test/str/saige-qtl/input_files/vcf/v1-chr-specific/hail_filtered_chr22.vcf.bgz \
     --str-locus=22:10515024-10515025 \
-    --window=22:10510212-10511391 \
+    --window=20:10000000-10511391 \
     --output-file=ld_results.csv
 
 """
@@ -55,6 +55,7 @@ def ld_parser(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str,
 
         # concatenate results to the main df
         df = pd.concat([df, df_to_append], axis=1)
+        df.to_csv(output_path+'snp', index=False)
     print("Finished subsetting VCF for window")
 
     # extract GTs for the one STR
@@ -78,9 +79,11 @@ def ld_parser(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str,
             ds_list.append(ds[i][0])
         target_data = {'individual': str_vcf.samples, str_locus: ds_list}
         target_df = pd.DataFrame(target_data)
+        target_df.to_csv(output_path+'str', index=False)
 
     # merge the two dataframes
     merged_df = df.merge(target_df, on='individual')
+    merged_df.to_csv(output_path+'merged', index=False)
 
     # calculate pairwise correlation of every SNP locus with target STR locus
     correlation_series = merged_df.drop(columns='individual').corrwith(merged_df[str_locus])

--- a/str/coloc/ld_parser.py
+++ b/str/coloc/ld_parser.py
@@ -8,22 +8,23 @@ Outputs the locus-level LD results as a TSV file.
 analysis-runner --dataset "bioheart" \
     --description "Calculate LD between STR and SNPs" \
     --access-level "test" \
-    --cpu=4 \
+    --cpu=1 \
     --output-dir "str/ld/test-run" \
     ld_parser.py --snp-vcf-path=gs://cpg-bioheart-test/str/dummy_snp_vcf/chr20_common_variants_renamed.vcf.bgz \
     --str-vcf-path=gs://cpg-bioheart-test/str/saige-qtl/input_files/vcf/v1-chr-specific/hail_filtered_chr22.vcf.bgz \
     --str-locus=22:10515024-10515025 \
-    --window=20:10000000-10511391 \
+    --window=20:10500000-10511391 \
     --output-file=ld_results.csv
 
 """
 
 import click
+import pandas as pd
 
 from cpg_utils.config import output_path
 
 
-def ld_parser(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str, output_path: str):
+def ld_parser(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str, output_path: str, gwas_snp_path: str):
     import pandas as pd
     from cyvcf2 import VCF
 
@@ -118,8 +119,64 @@ def ld_parser(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str,
     help='Output file name with .csv.',
     type=str,
 )
+@click.option('--coloc-dir', help='GCS file path to coloc results', type=str)
+@click.option('--phenotype', help='Phenotype to use for coloc', type=str)
+@click.option('--celltypes', help='Cell types to use for coloc', type=str)
+@click.option('--gene-annotation-file', help='Path to gene annotation file', default = 'gs://cpg-bioheart-test/str/240_libraries_tenk10kp1_v2/concatenated_gene_info_donor_info_var.csv')
+@click.option('--str-fdr-dir', help='Path to STR FDR dir', default = 'gs://cpg-bioheart-test/str/associatr/tob_n1055_and_bioheart_n990/DL_random_model/meta_results/fdr_qvals/using_acat')
 @click.command()
-def main(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str, output_file: str):
+def main(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str, output_file: str, coloc_dir: str, phenotype: str, celltypes: str, gene_annotation_file: str):
+
+    for celltype in celltypes.split(','):
+        # read in STR eGene annotation file
+        str_fdr_file = f'{str_fdr_dir}/{celltype}_qval.tsv'
+        str_fdr = pd.read_csv(str_fdr_file, sep='\t')
+        str_fdr = str_fdr[str_fdr['qval'] < 0.05] # subset to eGenes passing FDR 5% threshold
+
+
+        coloc_result_file = f'{coloc_dir}/{phenotype}/{celltype}_coloc_results.csv'
+        coloc_results = pd.read_csv(coloc_result_file)
+        # subset results for posterior probability of a shared causal variant >=0.5
+        coloc_results = coloc_results[coloc_results['PP.H4.abf'] >= 0.5]
+
+        #obtain inputs for LD parsing for each entry in `coloc_results`:
+        for index, row in coloc_results.iterrows():
+            gene = row['gene']
+            # obtain snp cis-window coordinates for the gene
+            gene_annotation_table = pd.read_csv(gene_annotation_file)
+            gene_table = gene_annotation_table[gene_annotation_table['gene_ids']==gene] #subset to particular ENSG ID
+            start_snp_window = float(gene_table['start'].astype(float)) -100000 # +-100kB window around gene
+            end_snp_window =  float(gene_table['end'].astype(float))+100000 # +-100kB window around gene
+            chr = gene_table['chr'].iloc[0][3:]
+            snp_window = f'{chr}:{start_snp_window}-{end_snp_window}'
+
+            #obtain top STR locus for the gene
+            str_fdr_gene = str_fdr[str_fdr['gene_name']==gene]
+            for estr in zip(eval(str_fdr_gene['chr'].iloc[0]), eval(str_fdr_gene['pos'].iloc[0])):
+                chr_num = estr[0][3:0]
+                pos = estr[1]
+                end = int(pos) + 1
+                str_locus = f'{chr_num}:{pos}-{end}'
+                print(f'Running LD for {gene} and {str_locus}')
+                ld_parser(snp_vcf_path, str_vcf_path, str_locus, snp_window, output_path(f'{gene}_{str_locus}/{output_file}', 'analysis'))
+
+
+
+
+
+
+
+
+
+
+
+            #obtain the +/- 100kB window around each gene
+
+
+        #obtain the coordinates for each gene
+
+
+
     chr, pos = str_locus.split(':')
     ld_parser(snp_vcf_path, str_vcf_path, str_locus, window, output_path(f'{chr}_{pos}/{output_file}', 'analysis'))
 

--- a/str/coloc/ld_parser.py
+++ b/str/coloc/ld_parser.py
@@ -106,7 +106,7 @@ def ld_parser(
 
     # find the SNP with the highest absolute correlation
     max_correlation_index = correlation_df['correlation'].abs().idxmax()
-    max_correlation_df = correlation_df.loc[correlation_df.loc[[max_correlation_index]]]
+    max_correlation_df = correlation_df[correlation_df['locus'] ==max_correlation_index]
 
     # add some attributes
     max_correlation_df['gene'] = gene
@@ -183,7 +183,7 @@ def main(
             # obtain top STR locus for the gene
             str_fdr_gene = str_fdr[str_fdr['gene_name'] == gene]
             for estr in zip(ast.literal_eval(str_fdr_gene['chr'].iloc[0]), ast.literal_eval(str_fdr_gene['pos'].iloc[0])):
-                chr_num = estr[0][3:0]
+                chr_num = estr[0][3:]
                 pos = estr[1]
                 end = int(pos) + 1
                 str_locus = f'{chr_num}:{pos}-{end}'

--- a/str/coloc/ld_parser.py
+++ b/str/coloc/ld_parser.py
@@ -160,7 +160,7 @@ def main(
         str_fdr = pd.read_csv(str_fdr_file, sep='\t')
         str_fdr = str_fdr[str_fdr['qval'] < 0.05]  # subset to eGenes passing FDR 5% threshold
 
-        coloc_result_file = f'{coloc_dir}/{phenotype}/{celltype}_coloc_results.csv'
+        coloc_result_file = f'{coloc_dir}/{phenotype}/{celltype}/gene_summary_result.csv'
         coloc_results = pd.read_csv(coloc_result_file)
         # subset results for posterior probability of a shared causal variant >=0.5
         coloc_results = coloc_results[coloc_results['PP.H4.abf'] >= 0.5]

--- a/str/coloc/ld_parser.py
+++ b/str/coloc/ld_parser.py
@@ -12,11 +12,15 @@ analysis-runner --dataset "bioheart" \
     --output-dir "str/ld/test-run" \
     ld_parser.py --snp-vcf-path=gs://cpg-bioheart-test/str/dummy_snp_vcf/chr20_common_variants_renamed.vcf.bgz \
     --str-vcf-path=gs://cpg-bioheart-test/str/saige-qtl/input_files/vcf/v1-chr-specific/hail_filtered_chr22.vcf.bgz \
-    --str-locus=22:10515024-10515025 \
-    --window=20:10500000-10511391 \
-    --output-file=ld_results.csv
+    --output-file=ld_results.csv \
+    --coloc-dir=gs://cpg-bioheart-test/str/associatr/coloc \
+    --phenotype=ibd \
+    --celltypes=CD4_TCM
+
 
 """
+
+import ast
 
 import click
 import pandas as pd
@@ -24,7 +28,9 @@ import pandas as pd
 from cpg_utils.config import output_path
 
 
-def ld_parser(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str, output_path: str, gwas_snp_path: str, gene:str):
+def ld_parser(
+    snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str, output_path: str, gwas_snp_path: str, gene: str,
+):
     import pandas as pd
     from cyvcf2 import VCF
 
@@ -56,7 +62,7 @@ def ld_parser(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str,
 
         # concatenate results to the main df
         df = pd.concat([df, df_to_append], axis=1)
-        df.to_csv(output_path+'snp', index=False)
+        df.to_csv(output_path + 'snp', index=False)
     print("Finished subsetting VCF for window")
 
     # extract GTs for the one STR
@@ -80,28 +86,27 @@ def ld_parser(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str,
             ds_list.append(ds[i][0])
         target_data = {'individual': str_vcf.samples, str_locus: ds_list}
         target_df = pd.DataFrame(target_data)
-        target_df.to_csv(output_path+'str', index=False)
+        target_df.to_csv(output_path + 'str', index=False)
 
     # merge the two dataframes
     merged_df = df.merge(target_df, on='individual')
-    merged_df.to_csv(output_path+'merged', index=False)
+    merged_df.to_csv(output_path + 'merged', index=False)
 
     # calculate pairwise correlation of every SNP locus with target STR locus
     correlation_series = merged_df.drop(columns='individual').corrwith(merged_df[str_locus])
-
 
     correlation_df = pd.DataFrame(correlation_series, columns=['correlation'])
     correlation_df['locus'] = correlation_df.index
     # drop the STR locus from the list of SNPs (it will automatically have a correlation of 1)
     correlation_df = correlation_df[correlation_df['locus'] != str_locus]
 
-    #keep only the SNPs that are in the GWAS catalog
-    gwas_snps = pd.read_csv(gwas_snp_path)
-    filtered_df = correlation_df[correlation_df['locus'].isin(gwas_snps['locus'])]
+    # keep only the SNPs that are in the GWAS catalog
+    # gwas_snps = pd.read_csv(gwas_snp_path)
+    # correlation_df = correlation_df[correlation_df['locus'].isin(gwas_snps['locus'])]
 
-    #find the SNP with the highest absolute correlation
-    max_correlation_index = filtered_df[f'correlation'].abs().idxmax()
-    max_correlation_df = filtered_df.loc[filtered_df.loc[[max_correlation_index]]]
+    # find the SNP with the highest absolute correlation
+    max_correlation_index = correlation_df['correlation'].abs().idxmax()
+    max_correlation_df = correlation_df.loc[correlation_df.loc[[max_correlation_index]]]
 
     # add some attributes
     max_correlation_df['gene'] = gene
@@ -121,16 +126,6 @@ def ld_parser(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str,
     type=str,
 )
 @click.option(
-    '--str-locus',
-    help='STR locus to calculate LD with.',
-    type=str,
-)
-@click.option(
-    '--window',
-    help='Window size to calculate LD within.',
-    type=str,
-)
-@click.option(
     '--output-file',
     help='Output file name with .csv.',
     type=str,
@@ -138,63 +133,74 @@ def ld_parser(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str,
 @click.option('--coloc-dir', help='GCS file path to coloc results', type=str)
 @click.option('--phenotype', help='Phenotype to use for coloc', type=str)
 @click.option('--celltypes', help='Cell types to use for coloc', type=str)
-@click.option('--gene-annotation-file', help='Path to gene annotation file', default = 'gs://cpg-bioheart-test/str/240_libraries_tenk10kp1_v2/concatenated_gene_info_donor_info_var.csv')
-@click.option('--str-fdr-dir', help='Path to STR FDR dir', default = 'gs://cpg-bioheart-test/str/associatr/tob_n1055_and_bioheart_n990/DL_random_model/meta_results/fdr_qvals/using_acat')
+@click.option(
+    '--gene-annotation-file',
+    help='Path to gene annotation file',
+    default='gs://cpg-bioheart-test/str/240_libraries_tenk10kp1_v2/concatenated_gene_info_donor_info_var.csv',
+)
+@click.option(
+    '--str-fdr-dir',
+    help='Path to STR FDR dir',
+    default='gs://cpg-bioheart-test/str/associatr/tob_n1055_and_bioheart_n990/DL_random_model/meta_results/fdr_qvals/using_acat',
+)
 @click.command()
-def main(snp_vcf_path: str, str_vcf_path: str, str_locus: str, window: str, output_file: str, coloc_dir: str, phenotype: str, celltypes: str, gene_annotation_file: str):
-
+def main(
+    snp_vcf_path: str,
+    str_vcf_path: str,
+    output_file: str,
+    coloc_dir: str,
+    phenotype: str,
+    celltypes: str,
+    gene_annotation_file: str,
+    str_fdr_dir: str,
+):
     for celltype in celltypes.split(','):
         # read in STR eGene annotation file
         str_fdr_file = f'{str_fdr_dir}/{celltype}_qval.tsv'
         str_fdr = pd.read_csv(str_fdr_file, sep='\t')
-        str_fdr = str_fdr[str_fdr['qval'] < 0.05] # subset to eGenes passing FDR 5% threshold
-
+        str_fdr = str_fdr[str_fdr['qval'] < 0.05]  # subset to eGenes passing FDR 5% threshold
 
         coloc_result_file = f'{coloc_dir}/{phenotype}/{celltype}_coloc_results.csv'
         coloc_results = pd.read_csv(coloc_result_file)
         # subset results for posterior probability of a shared causal variant >=0.5
         coloc_results = coloc_results[coloc_results['PP.H4.abf'] >= 0.5]
 
-        #obtain inputs for LD parsing for each entry in `coloc_results`:
-        for index, row in coloc_results.iterrows():
-            gene = row['gene']
+        # obtain inputs for LD parsing for each entry in `coloc_results`:
+        # for index, row in coloc_results.iterrows():
+        for gene in ['ENSG00000079691']:
+            # gene = row['gene']
             # obtain snp cis-window coordinates for the gene
             gene_annotation_table = pd.read_csv(gene_annotation_file)
-            gene_table = gene_annotation_table[gene_annotation_table['gene_ids']==gene] #subset to particular ENSG ID
-            start_snp_window = float(gene_table['start'].astype(float)) -100000 # +-100kB window around gene
-            end_snp_window =  float(gene_table['end'].astype(float))+100000 # +-100kB window around gene
+            gene_table = gene_annotation_table[
+                gene_annotation_table['gene_ids'] == gene
+            ]  # subset to particular ENSG ID
+            start_snp_window = float(gene_table['start'].astype(float)) - 100000  # +-100kB window around gene
+            end_snp_window = float(gene_table['end'].astype(float)) + 100000  # +-100kB window around gene
             chr = gene_table['chr'].iloc[0][3:]
             snp_window = f'{chr}:{start_snp_window}-{end_snp_window}'
+            snp_window = '20:10500000-10511391'
 
-            #obtain top STR locus for the gene
-            str_fdr_gene = str_fdr[str_fdr['gene_name']==gene]
-            for estr in zip(eval(str_fdr_gene['chr'].iloc[0]), eval(str_fdr_gene['pos'].iloc[0])):
+            # obtain top STR locus for the gene
+            str_fdr_gene = str_fdr[str_fdr['gene_name'] == gene]
+            for estr in zip(ast.literal_eval(str_fdr_gene['chr'].iloc[0]), ast.literal_eval(str_fdr_gene['pos'].iloc[0])):
                 chr_num = estr[0][3:0]
                 pos = estr[1]
                 end = int(pos) + 1
                 str_locus = f'{chr_num}:{pos}-{end}'
+                str_locus = '22:10515024-10515025'
                 print(f'Running LD for {gene} and {str_locus}')
-                ld_parser(snp_vcf_path, str_vcf_path, str_locus, snp_window, output_path(f'{gene}_{str_locus}/{output_file}', 'analysis'))
-
-
-
-
-
-
-
-
-
-
-
-            #obtain the +/- 100kB window around each gene
-
-
-        #obtain the coordinates for each gene
-
-
-
-    chr, pos = str_locus.split(':')
-    ld_parser(snp_vcf_path, str_vcf_path, str_locus, window, output_path(f'{chr}_{pos}/{output_file}', 'analysis'))
+                gwas_snp_path = f'{coloc_dir}/{phenotype}/{celltype}/{gene}_snp_gwas_list.csv'
+                ld_parser(
+                    snp_vcf_path,
+                    str_vcf_path,
+                    str_locus,
+                    snp_window,
+                    output_path(
+                        f'coloc_str_ld/{phenotype}/{celltype}/{gene}_chr{chr_num}_{pos}/{output_file}', 'analysis',
+                    ),
+                    gwas_snp_path,
+                    gene,
+                )
 
 
 if __name__ == '__main__':

--- a/str/coloc/ld_parser.py
+++ b/str/coloc/ld_parser.py
@@ -35,6 +35,7 @@ import ast
 import click
 import pandas as pd
 
+from cpg_utils.hail_batch import get_batch
 from cpg_utils.config import output_path
 
 
@@ -183,6 +184,7 @@ def main(
             end_snp_window = float(gene_table['end'].astype(float)) + 100000  # +-100kB window around gene
             chr = gene_table['chr'].iloc[0][3:]
             snp_window = f'{chr}:{start_snp_window}-{end_snp_window}'
+            print('Obtained SNP window coordinates')
 
 
             # obtain top STR locus for the gene
@@ -192,12 +194,20 @@ def main(
                 pos = estr[1]
                 end = str(int(pos) + 1)
                 str_locus = f'{chr_num}:{pos}-{end}'
+                #for testing only
                 str_locus = '22:10515024-10515025'
+                chr_num = '22'
                 print(f'Running LD for {gene} and {str_locus}')
                 gwas_snp_path = f'{coloc_dir}/{phenotype}/{celltype}/{gene}_snp_gwas_list.csv'
                 snp_vcf_path = f'{snp_vcf_dir}/chr{chr_num}_common_variants_renamed.vcf.bgz'
                 str_vcf_path = f'{str_vcf_dir}/hail_filtered_chr{chr_num}.vcf.bgz'
-                ld_parser(
+                # run coloc
+                b = get_batch()
+                ld_job = b.new_python_job(
+                    f'LD calc for {gene} and STR: {str_locus}; {celltype}',
+                )
+                ld_job(
+                ld_parser,
                     snp_vcf_path,
                     str_vcf_path,
                     str_locus,

--- a/str/coloc/ld_runner.py
+++ b/str/coloc/ld_runner.py
@@ -100,6 +100,7 @@ def ld_parser(
             ds_list.append(ds[i][0])
         target_data = {'individual': str_vcf.samples, str_locus: ds_list}
         target_df = pd.DataFrame(target_data)
+        break # take the first STR locus
 
     # merge the two dataframes
     merged_df = df.merge(target_df, on='individual')

--- a/str/coloc/ld_runner.py
+++ b/str/coloc/ld_runner.py
@@ -100,8 +100,7 @@ def ld_parser(
             ds_list.append(ds[i][0])
         target_data = {'individual': str_vcf.samples, str_locus: ds_list}
         target_df = pd.DataFrame(target_data)
-        target_df.to_csv(f'{output_path}.target.{variant.POS}', index=False)
-        break # take the first STR locus
+        break  # take the first STR locus
 
     # merge the two dataframes
     merged_df = df.merge(target_df, on='individual')
@@ -175,9 +174,8 @@ def main(
         coloc_results = coloc_results[coloc_results['PP.H4.abf'] >= 0.5]
 
         # obtain inputs for LD parsing for each entry in `coloc_results`:
-        #for index, row in coloc_results.iterrows():
-        for gene in ['ENSG00000196421','ENSG00000197457']:
-            #gene = row['gene']
+        for index, row in coloc_results.iterrows():
+            gene = row['gene']
             # obtain snp cis-window coordinates for the gene
             gene_annotation_table = pd.read_csv(gene_annotation_file)
             gene_table = gene_annotation_table[

--- a/str/coloc/ld_runner.py
+++ b/str/coloc/ld_runner.py
@@ -100,6 +100,7 @@ def ld_parser(
             ds_list.append(ds[i][0])
         target_data = {'individual': str_vcf.samples, str_locus: ds_list}
         target_df = pd.DataFrame(target_data)
+        target_df.to_csv(f'{output_path}.target.{variant.POS}', index=False)
         break # take the first STR locus
 
     # merge the two dataframes
@@ -196,8 +197,8 @@ def main(
             ):
                 chr_num = estr[0][3:]
                 pos = estr[1]
-                #end = str(int(pos) + 1)
-                #str_locus = f'{chr_num}:{pos}-{end}'
+                end = str(int(pos) + 1)
+                str_locus = f'{chr_num}:{pos}-{end}'
                 str_locus=f'{chr_num}:{pos}'
                 print(f'Running LD for {gene} and {str_locus}')
                 gwas_snp_path = f'{coloc_dir}/{phenotype}/{celltype}/{gene}_snp_gwas_list.csv'

--- a/str/coloc/ld_runner.py
+++ b/str/coloc/ld_runner.py
@@ -173,8 +173,9 @@ def main(
         coloc_results = coloc_results[coloc_results['PP.H4.abf'] >= 0.5]
 
         # obtain inputs for LD parsing for each entry in `coloc_results`:
-        for index, row in coloc_results.iterrows():
-            gene = row['gene']
+        #for index, row in coloc_results.iterrows():
+        for gene in ['ENSG00000196421','ENSG00000197457']:
+            #gene = row['gene']
             # obtain snp cis-window coordinates for the gene
             gene_annotation_table = pd.read_csv(gene_annotation_file)
             gene_table = gene_annotation_table[

--- a/str/coloc/ld_runner.py
+++ b/str/coloc/ld_runner.py
@@ -46,6 +46,7 @@ def ld_parser(
     output_path: str,
     gwas_snp_path: str,
     gene: str,
+    celltype: str,
 ):
     import pandas as pd
     from cyvcf2 import VCF
@@ -125,6 +126,7 @@ def ld_parser(
     # add some attributes
     max_correlation_df['gene'] = gene
     max_correlation_df['str_locus'] = str_locus
+    max_correlation_df['celltype'] = celltype
 
     max_correlation_df.to_csv(output_path, index=False)
 
@@ -218,6 +220,7 @@ def main(
                     ),
                     gwas_snp_path,
                     gene,
+                    celltype,
                 )
             b.run(wait=False)
 

--- a/str/coloc/ld_runner.py
+++ b/str/coloc/ld_runner.py
@@ -21,7 +21,7 @@ analysis-runner --dataset "bioheart" \
     --access-level "test" \
     --cpu=1 \
     --output-dir "str/ld/test-run" \
-    ld_parser.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf \
+    ld_runner.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf \
     --str-vcf-dir=gs://cpg-bioheart-test/str/saige-qtl/input_files/vcf/v1-chr-specific \
     --coloc-dir=gs://cpg-bioheart-test/str/associatr/coloc \
     --phenotype=ibd \
@@ -63,7 +63,6 @@ def ld_parser(
 
     # create empty DF to store the relevant GTs (SNPs)
     df = pd.DataFrame(columns=['individual'])
-    print('Created empty dataframe')
 
     # cyVCF2 reads the SNP VCF
     vcf = VCF(local_file)
@@ -78,7 +77,6 @@ def ld_parser(
 
         # concatenate results to the main df
         df = pd.concat([df, df_to_append], axis=1)
-        df.to_csv(output_path + 'snp', index=False)
     print("Finished subsetting VCF for window")
 
     # extract GTs for the one STR
@@ -102,11 +100,9 @@ def ld_parser(
             ds_list.append(ds[i][0])
         target_data = {'individual': str_vcf.samples, str_locus: ds_list}
         target_df = pd.DataFrame(target_data)
-        target_df.to_csv(output_path + 'str', index=False)
 
     # merge the two dataframes
     merged_df = df.merge(target_df, on='individual')
-    merged_df.to_csv(output_path + 'merged', index=False)
 
     # calculate pairwise correlation of every SNP locus with target STR locus
     correlation_series = merged_df.drop(columns='individual').corrwith(merged_df[str_locus])

--- a/str/coloc/ld_runner.py
+++ b/str/coloc/ld_runner.py
@@ -196,8 +196,9 @@ def main(
             ):
                 chr_num = estr[0][3:]
                 pos = estr[1]
-                end = str(int(pos) + 1)
-                str_locus = f'{chr_num}:{pos}-{end}'
+                #end = str(int(pos) + 1)
+                #str_locus = f'{chr_num}:{pos}-{end}'
+                str_locus=f'{chr_num}:{pos}'
                 print(f'Running LD for {gene} and {str_locus}')
                 gwas_snp_path = f'{coloc_dir}/{phenotype}/{celltype}/{gene}_snp_gwas_list.csv'
                 snp_vcf_path = f'{snp_vcf_dir}/chr{chr}_common_variants_renamed.vcf.bgz'

--- a/str/coloc/ld_runner.py
+++ b/str/coloc/ld_runner.py
@@ -199,7 +199,6 @@ def main(
                 pos = estr[1]
                 end = str(int(pos) + 1)
                 str_locus = f'{chr_num}:{pos}-{end}'
-                str_locus=f'{chr_num}:{pos}'
                 print(f'Running LD for {gene} and {str_locus}')
                 gwas_snp_path = f'{coloc_dir}/{phenotype}/{celltype}/{gene}_snp_gwas_list.csv'
                 snp_vcf_path = f'{snp_vcf_dir}/chr{chr}_common_variants_renamed.vcf.bgz'


### PR DESCRIPTION
Step after colocalisation. 

Essentially, colocalisation compares signals between SNP eQTLs and SNPs in a GWAS (whether the signals look similar at a gene expression and a phenotype level respectively). 

Most GWAS catalogs are SNPs. So when we add STRs into the mix we do the usual SNP-SNP colocalisation between the eQTLs and GWAS, and then we can link in the STR by showing that the top eSTR associated with that gene is in LD with at least one SNP in the GWAS locus. 

This script calculates the LD. 

Specifically, the workflow: 
1)Extract genes that have >50% posterior probability of a shared causal variant from coloc results.
2) Extract the coordinates of the cis-window (gene +/- 100kB) for each gene using a gene annotation file.
3) Extract the top STR locus (ie passed FDR 5% threshold) for each gene in 1). May be multiple STRs per gene (if tied for smallest ACAT-corrected p-value).
4) Run LD parser() which:
- Extracts GTs for all SNPs (from a chr-specific VCF) in the cis-window for a gene.
- Extracts GTs for the specified STR locus associated with the gene.
- Calculates pairwise correlation of every SNP locus with the target STR locus.
- Save the SNP with the highest absolute correlation to a TSV file. Output to GCP
