### PR TITLE
GWAS-LD script update (I hope this is the last one)

### DIFF
--- a/str/coloc/gwas_ld_runner.py
+++ b/str/coloc/gwas_ld_runner.py
@@ -13,10 +13,10 @@ Workflow:
 
 analysis-runner --dataset "bioheart" \
     --description "Calculate LD between STR and SNPs" \
-    --access-level "full" \
+    --access-level "test" \
     --cpu=1 \
     --output-dir "str/associatr/freeze_1/gwas_ld/bioheart-only-snps" \
-    gwas_ld_runner.py --snp-vcf-dir=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/genotypes/vds-bioheart1-0 \
+    gwas_ld_runner.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf \
     --str-vcf-dir=gs://cpg-bioheart-test/str/saige-qtl/input_files/vcf/v1-chr-specific \
     --gwas-file=gs://cpg-bioheart-test/str/gwas_catalog/hg38.EUR.IBD.gwas_info03_filtered.assoc_for_gwas_ld.csv \
     --celltypes=CD4_TCM \
@@ -216,17 +216,17 @@ def main(
     job_storage: str,
     gwas_file: str,
 ):
-    b = get_batch()
+    b = get_batch(name = 'GWAS LD runner')
 
     for celltype in celltypes.split(','):
-        for chromosome in range(1, 23):
+        for chromosome in [20]:
             ld_job = b.new_python_job(
                 f'LD calc for chr{chromosome}; {celltype}',
             )
             ld_job.cpu(job_cpu)
             ld_job.storage(job_storage)
 
-            snp_vcf_path = f'{snp_vcf_dir}/chr{chromosome}_common_variants.vcf.bgz'
+            snp_vcf_path = f'{snp_vcf_dir}/chr{chromosome}_common_variants_renamed.vcf.bgz'
             str_vcf_path = f'{str_vcf_dir}/hail_filtered_chr{chromosome}.vcf.bgz'
 
             snp_input = get_batch().read_input_group(**{'vcf': snp_vcf_path, 'csi': snp_vcf_path + '.csi'})

--- a/str/coloc/gwas_ld_runner.py
+++ b/str/coloc/gwas_ld_runner.py
@@ -20,8 +20,7 @@ analysis-runner --dataset "bioheart" \
     --str-vcf-dir=gs://cpg-bioheart-test/str/saige-qtl/input_files/vcf/v1-chr-specific \
     --gwas-file=gs://cpg-bioheart-test/str/gwas_catalog/hg38.EUR.IBD.gwas_info03_filtered.assoc_for_gwas_ld.csv \
     --celltypes=CD4_TCM \
-    --phenotype=ibd \
-    --max-parallel-jobs 250
+    --phenotype=ibd
 
 """
 
@@ -94,7 +93,7 @@ def ld_parser(
 
         if gwas_catalog.empty:
             print('No SNP GWAS data for ' + gene + ' in the cis-window: skipping....')
-            return
+            continue
 
         # obtain lead SNP (lowest p-value) in the snp_window of the GWAS
         lowest_p_row = gwas_catalog.loc[gwas_catalog['P'].idxmin()]

--- a/str/coloc/gwas_ld_runner.py
+++ b/str/coloc/gwas_ld_runner.py
@@ -136,10 +136,14 @@ def ld_parser(
                 geno = variant.gt_types  # extracts GTs as a numpy array
                 locus = variant.CHROM + ':' + str(variant.POS)
                 df_to_append = pd.DataFrame(geno, columns=[locus])  # creates a temp df to store the GTs for one locus
-
-                # concatenate results to the main df
-                df = pd.concat([df, df_to_append], axis=1)
                 break  # take the first SNP locus
+
+            if df_to_append.empty:
+                print(f'No GTs for SNP {locus} in the VCF, skipping...')
+                continue
+
+            # concatenate results to the main df
+            df = pd.concat([df, df_to_append], axis=1)
             print("Finished subsetting VCF for lead SNP")
 
             # extract GTs for the one STR

--- a/str/coloc/gwas_ld_runner.py
+++ b/str/coloc/gwas_ld_runner.py
@@ -219,17 +219,17 @@ def main(
     job_storage: str,
     gwas_file: str,
 ):
-    b = get_batch(name = 'GWAS LD runner')
+    b = get_batch(name='GWAS LD runner')
 
     for celltype in celltypes.split(','):
-        for chromosome in [20]:
+        for chromosome in range(1, 23):
             ld_job = b.new_python_job(
                 f'LD calc for chr{chromosome}; {celltype}',
             )
             ld_job.cpu(job_cpu)
             ld_job.storage(job_storage)
 
-            snp_vcf_path = f'{snp_vcf_dir}/chr{chromosome}_common_variants_renamed.vcf.bgz'
+            snp_vcf_path = f'{snp_vcf_dir}/chr{chromosome}_common_variants.vcf.bgz'
             str_vcf_path = f'{str_vcf_dir}/hail_filtered_chr{chromosome}.vcf.bgz'
 
             snp_input = get_batch().read_input_group(**{'vcf': snp_vcf_path, 'csi': snp_vcf_path + '.csi'})

--- a/str/coloc/gwas_ld_runner.py
+++ b/str/coloc/gwas_ld_runner.py
@@ -13,10 +13,10 @@ Workflow:
 
 analysis-runner --dataset "bioheart" \
     --description "Calculate LD between STR and SNPs" \
-    --access-level "test" \
+    --access-level "full" \
     --cpu=1 \
     --output-dir "str/associatr/freeze_1/gwas_ld/bioheart-only-snps" \
-    gwas_ld_runner.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf \
+    gwas_ld_runner.py --snp-vcf-dir=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/genotypes/vds-bioheart1-0 \
     --str-vcf-dir=gs://cpg-bioheart-test/str/saige-qtl/input_files/vcf/v1-chr-specific \
     --gwas-file=gs://cpg-bioheart-test/str/gwas_catalog/hg38.EUR.IBD.gwas_info03_filtered.assoc_for_gwas_ld.csv \
     --celltypes=CD4_TCM \
@@ -35,16 +35,29 @@ import hailtop.batch as hb
 from cpg_utils.config import output_path
 from cpg_utils.hail_batch import get_batch
 
+# Function to process each element in the 'chr' column
+def process_chr_element(element):
+    try:
+        # Safely evaluate the string to a list
+        chr_list = ast.literal_eval(element)
+        # Ensure the list is not empty and the first element is a string
+        if chr_list and isinstance(chr_list[0], str):
+            # Slice the string starting from the fourth character
+            return chr_list[0][3:]
+    except (ValueError, SyntaxError):
+        # Handle cases where ast.literal_eval fails
+        return None
+
 
 def ld_parser(
-    snp_vcf_dir,
-    str_vcf_dir,
+    snp_vcf_path,
+    str_vcf_path,
     phenotype,
     celltype,
     gene_annotation_file,
     str_fdr_dir,
     gwas_file,
-    gene,
+    chromosome,
 ):
     import pandas as pd
     from cyvcf2 import VCF
@@ -55,127 +68,112 @@ def ld_parser(
     gwas_catalog_orig = pd.read_csv(gwas_file)
     # read in gene_annotation_table
     gene_annotation_table = pd.read_csv(gene_annotation_file)
-
-    # obtain snp cis-window coordinates for the gene
-    gene_table = gene_annotation_table[gene_annotation_table['gene_ids'] == gene]  # subset to particular ENSG ID
-    start_snp_window = float(gene_table['start'].astype(float)) - 100000  # +-100kB window around gene
-    end_snp_window = float(gene_table['end'].astype(float)) + 100000  # +-100kB window around gene
-    chrom = gene_table['chr'].iloc[0][3:]
-    print('Obtained SNP window coordinates')
-
-    # subset the gwas catalog to the snp_window
-    gwas_catalog = gwas_catalog_orig[gwas_catalog_orig['CHR'] == int(chrom)]
-    gwas_catalog = gwas_catalog[gwas_catalog['BP'] >= start_snp_window]
-    gwas_catalog = gwas_catalog[gwas_catalog['BP'] <= end_snp_window]
-
-    if gwas_catalog.empty:
-        print('No SNP GWAS data for ' + gene + ' in the cis-window: skipping....')
-        return
-
-    # obtain lead SNP (lowest p-value) in the snp_window of the GWAS
-    lowest_p_row = gwas_catalog.loc[gwas_catalog['P'].idxmin()]
-    lead_snp_chr = lowest_p_row['CHR']
-    lead_snp_bp = lowest_p_row['BP']
-    lead_snp_end = lowest_p_row['BP'] + 1
-    lead_snp_locus = f'{lead_snp_chr}:{lead_snp_bp}-{lead_snp_end}'
-
     # load in the str fdr file
     str_fdr_file = f'{str_fdr_dir}/{celltype}_qval.tsv'
     str_fdr = pd.read_csv(str_fdr_file, sep='\t')
+    str_fdr = str_fdr[str_fdr['qval'] < 0.05]  # subset to eGenes passing FDR 5% threshold
 
-    snp_vcf_path = f'{snp_vcf_dir}/chr{chrom}_common_variants.vcf.bgz'
-    str_vcf_path = f'{str_vcf_dir}/hail_filtered_chr{chrom}.vcf.bgz'
+    # Apply the function to the 'chr' column and create a new 'chrom' column
+    str_fdr['chrom_num'] = str_fdr['chr'].apply(process_chr_element)
+    str_fdr = str_fdr[str_fdr['chrom_num'] == str(chromosome)] # subset to the chromosome
 
-    # copy SNP VCF local because cyVCF2 can only read from a local file
-    local_file = 'local.vcf.bgz'
-    gcp_file = to_path(snp_vcf_path)
-    gcp_file_index = to_path(snp_vcf_path + '.csi')
-    gcp_file.copy(local_file)
-    print('Copied SNP VCF to local file')
-    gcp_file_index.copy(local_file + '.csi')
-    print('Copied SNP VCF index to local file')
+    for gene in str_fdr['gene_name']:
+        print(f'Processing gene: {gene}')
 
-    # start by copying STR VCF to local
-    local_str_file = 'local_str.vcf.bgz'
-    gcp_str_file = to_path(str_vcf_path)
-    gcp_str_file_index = to_path(str_vcf_path + '.csi')
-    gcp_str_file.copy(local_str_file)
-    print('Copied STR VCF to local file')
+        # obtain snp cis-window coordinates for the gene
+        gene_table = gene_annotation_table[gene_annotation_table['gene_ids'] == gene]  # subset to particular ENSG ID
+        start_snp_window = float(gene_table['start'].astype(float)) - 100000  # +-100kB window around gene
+        end_snp_window = float(gene_table['end'].astype(float)) + 100000  # +-100kB window around gene
+        chrom = gene_table['chr'].iloc[0][3:]
+        print('Obtained SNP window coordinates')
 
-    gcp_str_file_index.copy(local_str_file + '.csi')
-    print('Copied STR VCF index to local file')
+        # subset the gwas catalog to the snp_window
+        gwas_catalog = gwas_catalog_orig[gwas_catalog_orig['CHR'] == int(chrom)]
+        gwas_catalog = gwas_catalog[gwas_catalog['BP'] >= start_snp_window]
+        gwas_catalog = gwas_catalog[gwas_catalog['BP'] <= end_snp_window]
 
-    # obtain top STR locus for the gene (if multiple are tied - iterate over each)
-    str_fdr_gene = str_fdr[str_fdr['gene_name'] == gene]
-    for estr in zip(
-        ast.literal_eval(str_fdr_gene['chr'].iloc[0]),
-        ast.literal_eval(str_fdr_gene['pos'].iloc[0]),
-    ):
-        chr_num = estr[0][3:]
-        pos = estr[1]
-        end = str(int(pos) + 1)
-        str_locus = f'{chr_num}:{pos}-{end}'
-        write_path = output_path(
-            f'gwas_ld/{phenotype}/{celltype}/{gene}_chr{chr_num}_{pos}_gwas_ld_results.csv',
-            'analysis',
-        )
+        if gwas_catalog.empty:
+            print('No SNP GWAS data for ' + gene + ' in the cis-window: skipping....')
+            return
 
-        if to_path(write_path).exists():
-            print(f'GWAS LD for {gene} and {str_locus} already exists. Skipping...')
-            continue
+        # obtain lead SNP (lowest p-value) in the snp_window of the GWAS
+        lowest_p_row = gwas_catalog.loc[gwas_catalog['P'].idxmin()]
+        lead_snp_chr = lowest_p_row['CHR']
+        lead_snp_bp = lowest_p_row['BP']
+        lead_snp_end = lowest_p_row['BP'] + 1
+        lead_snp_locus = f'{lead_snp_chr}:{lead_snp_bp}-{lead_snp_end}'
 
-        print(f'Running LD for {gene} and {str_locus}')
+        # obtain top STR locus for the gene (if multiple are tied - iterate over each)
+        str_fdr_gene = str_fdr[str_fdr['gene_name'] == gene]
+        for estr in zip(
+            ast.literal_eval(str_fdr_gene['chr'].iloc[0]),
+            ast.literal_eval(str_fdr_gene['pos'].iloc[0]),
+        ):
+            chr_num = estr[0][3:]
+            pos = estr[1]
+            end = str(int(pos) + 1)
+            str_locus = f'{chr_num}:{pos}-{end}'
+            write_path = output_path(
+                f'gwas_ld/{phenotype}/{celltype}/{gene}_chr{chr_num}_{pos}_gwas_ld_results.csv',
+                'analysis',
+            )
 
-        # create empty DF to store the relevant GTs (SNPs)
-        df = pd.DataFrame(columns=['individual'])
+            if to_path(write_path).exists():
+                print(f'GWAS LD for {gene} and {str_locus} already exists. Skipping...')
+                continue
 
-        # cyVCF2 reads the SNP VCF
-        vcf = VCF(local_file)
-        df['individual'] = vcf.samples
-        print('Reading SNP VCF with VCF()')
+            print(f'Running LD for {gene} and {str_locus}')
 
-        print(f'Starting to subset VCF for the lead SNP {lead_snp_locus}')
-        for variant in vcf(lead_snp_locus):
-            geno = variant.gt_types  # extracts GTs as a numpy array
-            locus = variant.CHROM + ':' + str(variant.POS)
-            df_to_append = pd.DataFrame(geno, columns=[locus])  # creates a temp df to store the GTs for one locus
+            # create empty DF to store the relevant GTs (SNPs)
+            df = pd.DataFrame(columns=['individual'])
 
-            # concatenate results to the main df
-            df = pd.concat([df, df_to_append], axis=1)
-            break  # take the first SNP locus
-        print("Finished subsetting VCF for lead SNP")
+            # cyVCF2 reads the SNP VCF
+            vcf = VCF(snp_vcf_path['vcf'])
+            df['individual'] = vcf.samples
+            print('Reading SNP VCF with VCF()')
 
-        # extract GTs for the one STR
-        str_vcf = VCF(local_str_file)
-        for variant in str_vcf(str_locus):
-            print(f'Captured STR with POS:{variant.POS}')
-            ds = variant.format('DS')
-            ds_list = []
-            for i in range(len(ds)):
-                ds_list.append(ds[i][0])
-            target_data = {'individual': str_vcf.samples, str_locus: ds_list}
-            target_df = pd.DataFrame(target_data)
-            break  # take the first STR locus
+            print(f'Starting to subset VCF for the lead SNP {lead_snp_locus}')
+            for variant in vcf(lead_snp_locus):
+                geno = variant.gt_types  # extracts GTs as a numpy array
+                locus = variant.CHROM + ':' + str(variant.POS)
+                df_to_append = pd.DataFrame(geno, columns=[locus])  # creates a temp df to store the GTs for one locus
 
-        # merge the two dataframes
-        merged_df = df.merge(target_df, on='individual')
+                # concatenate results to the main df
+                df = pd.concat([df, df_to_append], axis=1)
+                break  # take the first SNP locus
+            print("Finished subsetting VCF for lead SNP")
 
-        # calculate pairwise correlation of every SNP locus with target STR locus
-        correlation_series = merged_df.drop(columns='individual').corrwith(merged_df[str_locus])
+            # extract GTs for the one STR
+            str_vcf = VCF(str_vcf_path['vcf'])
+            for variant in str_vcf(str_locus):
+                print(f'Captured STR with POS:{variant.POS}')
+                ds = variant.format('DS')
+                ds_list = []
+                for i in range(len(ds)):
+                    ds_list.append(ds[i][0])
+                target_data = {'individual': str_vcf.samples, str_locus: ds_list}
+                target_df = pd.DataFrame(target_data)
+                break  # take the first STR locus
 
-        correlation_df = pd.DataFrame(correlation_series, columns=['correlation'])
-        correlation_df['locus'] = correlation_df.index
+            # merge the two dataframes
+            merged_df = df.merge(target_df, on='individual')
 
-        # drop the STR locus from the list of SNPs (it will automatically have a correlation of 1)
-        correlation_df = correlation_df[correlation_df['locus'] != str_locus]
+            # calculate pairwise correlation of every SNP locus with target STR locus
+            correlation_series = merged_df.drop(columns='individual').corrwith(merged_df[str_locus])
 
-        # add some attributes
-        correlation_df['gene'] = gene
-        correlation_df['str_locus'] = str_locus
-        correlation_df['celltype'] = celltype
+            correlation_df = pd.DataFrame(correlation_series, columns=['correlation'])
+            correlation_df['locus'] = correlation_df.index
 
-        # write to output_path
-        correlation_df.to_csv(write_path, index=False)
+            # drop the STR locus from the list of SNPs (it will automatically have a correlation of 1)
+            correlation_df = correlation_df[correlation_df['locus'] != str_locus]
+
+            # add some attributes
+            correlation_df['gene'] = gene
+            correlation_df['str_locus'] = str_locus
+            correlation_df['celltype'] = celltype
+
+            # write to output_path
+            correlation_df.to_csv(write_path, index=False)
 
 
 @click.option(
@@ -206,7 +204,6 @@ def ld_parser(
 )
 @click.option('--job-cpu', default=1)
 @click.option('--job-storage', default='20G')
-@click.option('--max-parallel-jobs', default=100)
 @click.command()
 def main(
     snp_vcf_dir: str,
@@ -218,50 +215,36 @@ def main(
     job_cpu: int,
     job_storage: str,
     gwas_file: str,
-    max_parallel_jobs: int,
 ):
-    # Setup MAX concurrency by genes
-    _dependent_jobs: list[hb.batch.job.Job] = []
-
-    def manage_concurrency_for_job(job: hb.batch.job.Job):
-        """
-        To avoid having too many jobs running at once, we have to limit concurrency.
-        """
-        if len(_dependent_jobs) >= max_parallel_jobs:
-            job.depends_on(_dependent_jobs[-max_parallel_jobs])
-        _dependent_jobs.append(job)
 
     b = get_batch()
 
     for celltype in celltypes.split(','):
-        # read in STR eGene annotation file
-        str_fdr_file = f'{str_fdr_dir}/{celltype}_qval.tsv'
-        str_fdr = pd.read_csv(str_fdr_file, sep='\t')
-        str_fdr = str_fdr[str_fdr['qval'] < 0.05]  # subset to eGenes passing FDR 5% threshold
-
-        # obtain inputs for LD parsing for each entry in `str_fdr`:
-        for index, row in str_fdr.iterrows():
-            gene = row['gene_name']
-
-            # run ld
+        for chromosome in range(1, 23):
             ld_job = b.new_python_job(
-                f'LD calc for {gene}; {celltype}',
+                f'LD calc for chr{chromosome}; {celltype}',
             )
             ld_job.cpu(job_cpu)
             ld_job.storage(job_storage)
 
+
+            snp_vcf_path = f'{snp_vcf_dir}/chr{chromosome}_common_variants.vcf.bgz'
+            str_vcf_path = f'{str_vcf_dir}/hail_filtered_chr{chromosome}.vcf.bgz'
+
+            snp_input = get_batch().read_input_group(**{'vcf': snp_vcf_path, 'csi': snp_vcf_path + '.csi'})
+            str_input = get_batch().read_input_group(**{'vcf': str_vcf_path, 'csi': str_vcf_path + '.csi'})
+
             ld_job.call(
                 ld_parser,
-                snp_vcf_dir,
-                str_vcf_dir,
+                snp_input,
+                str_input,
                 phenotype,
                 celltype,
                 gene_annotation_file,
                 str_fdr_dir,
                 gwas_file,
-                gene,
+                chromosome,
             )
-            manage_concurrency_for_job(ld_job)
 
     b.run(wait=False)
 

--- a/str/coloc/gwas_ld_runner.py
+++ b/str/coloc/gwas_ld_runner.py
@@ -81,8 +81,8 @@ def ld_parser(
 
         # obtain snp cis-window coordinates for the gene
         gene_table = gene_annotation_table[gene_annotation_table['gene_ids'] == gene]  # subset to particular ENSG ID
-        start_snp_window = float(gene_table['start'].astype(float)) - 100000  # +-100kB window around gene
-        end_snp_window = float(gene_table['end'].astype(float)) + 100000  # +-100kB window around gene
+        start_snp_window = float(gene_table['start'].iloc[0]) - 100000  # +-100kB window around gene
+        end_snp_window = float(gene_table['end'].iloc[0]) + 100000
         chrom = gene_table['chr'].iloc[0][3:]
         print('Obtained SNP window coordinates')
 

--- a/str/coloc/gwas_ld_runner.py
+++ b/str/coloc/gwas_ld_runner.py
@@ -35,6 +35,7 @@ import hailtop.batch as hb
 from cpg_utils.config import output_path
 from cpg_utils.hail_batch import get_batch
 
+
 # Function to process each element in the 'chr' column
 def process_chr_element(element):
     try:
@@ -59,7 +60,6 @@ def ld_parser(
     gwas_file,
     chromosome,
 ):
-    import pandas as pd
     from cyvcf2 import VCF
 
     from cpg_utils import to_path
@@ -75,7 +75,7 @@ def ld_parser(
 
     # Apply the function to the 'chr' column and create a new 'chrom' column
     str_fdr['chrom_num'] = str_fdr['chr'].apply(process_chr_element)
-    str_fdr = str_fdr[str_fdr['chrom_num'] == str(chromosome)] # subset to the chromosome
+    str_fdr = str_fdr[str_fdr['chrom_num'] == str(chromosome)]  # subset to the chromosome
 
     for gene in str_fdr['gene_name']:
         print(f'Processing gene: {gene}')
@@ -216,7 +216,6 @@ def main(
     job_storage: str,
     gwas_file: str,
 ):
-
     b = get_batch()
 
     for celltype in celltypes.split(','):
@@ -226,7 +225,6 @@ def main(
             )
             ld_job.cpu(job_cpu)
             ld_job.storage(job_storage)
-
 
             snp_vcf_path = f'{snp_vcf_dir}/chr{chromosome}_common_variants.vcf.bgz'
             str_vcf_path = f'{str_vcf_dir}/hail_filtered_chr{chromosome}.vcf.bgz'


### PR DESCRIPTION
The latest run was 1) a bit expensive and 2) cascade of cancelled jobs failing because they were 'dependent' on a failed job
https://batch.hail.populationgenomics.org.au/batches/447694

This update: 
1) Batches jobs by chromosome (not gene). This means that there are 22 jobs per cell type. This should reduce the cost because big files (eg GWAS catalog and the gene annotation files) are only read once per chromosome (instead of being re-read for every gene). This should also fix the cancelled jobs issue because we can take out the max-concurrent cap which creates dependency between jobs that are actually independent from each other. 

2) Revert back to reading in SNP VCF and STR VCF using batch temp dir - hopefully this solves the issue of batch failing to use the mounted storage. 