### PR TITLE
Rework logic of dropping monomorphic loci

### DIFF
--- a/str/associatr/helper/snp_vcf_for_associatr.py
+++ b/str/associatr/helper/snp_vcf_for_associatr.py
@@ -71,10 +71,19 @@ def reformat_vcf(vcf_file_path, output_file_path):
                 # Update FORMAT field
                 updated_format_field = 'GT:ADFL:ADIR:ADSP:LC:REPCI:REPCN:SO:QUAL'
 
-                # Check if all GT values are the same across all samples
-                gt_values = [sample.split(':')[0].replace('|', '/') for sample in sample_data]
-                if all(gt == gt_values[0] for gt in gt_values):
-                    continue  # Skip writing this line if all GT values are the same
+                # Check if all GT sums are the same across all samples, excluding missing GT values
+                summed_gt_values = []
+                for sample in sample_data:
+                    gt = sample.split(':')[0].replace('|', '/')
+                    if gt != './.':
+                        alleles = gt.split('/')
+                        if alleles[0] != '.' and alleles[1] != '.':
+                            gt_sum = int(alleles[0]) + int(alleles[1])
+                            summed_gt_values.append(gt_sum)
+
+                # Skip writing this line if all summed GT values are the same or if all GT values are missing
+                if len(summed_gt_values) == 0 or all(sum_gt == summed_gt_values[0] for sum_gt in summed_gt_values):
+                    continue
 
                 # Update sample data
                 updated_sample_data = []


### PR DESCRIPTION
The code in its current state only compares the GT string eg "0/1" or "./." or "1/0" for string equivalency and doesn't write the locus to the output file if each GT string across all samples are the same. 

This is a logic error
 - because associaTR uses the summed GT; so for example "0/1" and "1/0" have the same summed GT of 1. If a locus consists of GTs strictly "0/1" and "1/0", we should be throwing them out as well because associaTR will throw an error saying they are monomorphic as the summed GT are all equal to 1. In the current state of the script "0/1" and "1/0" are considered as distinct genotypes so the locus would be retained.

I think this ^ is what is causing the failure for 3% of my associatr jobs see here: https://centrepopgen.slack.com/archives/C063WDT5HT4/p1716152401429329 and https://batch.hail.populationgenomics.org.au/batches/450073?q=state%3Dfailed. 

To test this out, after merging this change into `main`, I'm going to run the pipeline on all chromosomes in one cell type. If this is the culprit, all the failed jobs should now be resolved and should be able to successfully run. 

Confirming this works in test - https://batch.hail.populationgenomics.org.au/batches/451044/jobs/1

