### PR TITLE
Add ALT allele to the "RU" field in the mock EH VCF

### DIFF
--- a/str/associatr/helper/snp_vcf_for_associatr.py
+++ b/str/associatr/helper/snp_vcf_for_associatr.py
@@ -66,7 +66,14 @@ def reformat_vcf(vcf_file_path, output_file_path):
 
                 # Update INFO field (add new fields required by ExpansionHunter, filler fields eg REF =0)
                 # RU stores the alt_allele; this will allow us to discriminate between loci with the same POS
-                new_info_fields = [f'END={parts[1]}', 'REF=3', f'REPID={pid}', 'RL=0', f'RU={parts[3]}-{parts[4]}', f'VARID={pid}']
+                new_info_fields = [
+                    f'END={parts[1]}',
+                    'REF=3',
+                    f'REPID={pid}',
+                    'RL=0',
+                    f'RU={parts[3]}-{parts[4]}',
+                    f'VARID={pid}',
+                ]
                 updated_info_field = ';'.join(new_info_fields)
 
                 # Update FORMAT field

--- a/str/associatr/helper/snp_vcf_for_associatr.py
+++ b/str/associatr/helper/snp_vcf_for_associatr.py
@@ -66,7 +66,7 @@ def reformat_vcf(vcf_file_path, output_file_path):
 
                 # Update INFO field (add new fields required by ExpansionHunter, filler fields eg REF =0)
                 # RU stores the alt_allele; this will allow us to discriminate between loci with the same POS
-                new_info_fields = [f'END={parts[1]}', 'REF=3', f'REPID={pid}', 'RL=0', f'RU={parts[4]}', f'VARID={pid}']
+                new_info_fields = [f'END={parts[1]}', 'REF=3', f'REPID={pid}', 'RL=0', f'RU={parts[3]}-{parts[4]}', f'VARID={pid}']
                 updated_info_field = ';'.join(new_info_fields)
 
                 # Update FORMAT field

--- a/str/associatr/helper/snp_vcf_for_associatr.py
+++ b/str/associatr/helper/snp_vcf_for_associatr.py
@@ -2,7 +2,11 @@
 
 """
 This script is used to convert existing SNP VCF files (chromosome-specific) into a mock ExpansionHunter-style VCF for direct use with associaTR.
-Also performs bgzipping and tabixing of the output VCF file.
+
+Please note ad-hoc changes:
+- RU field stores the REF and ALT alleles in the format of 'REF-ALT'
+- RL field is set to 0 for all loci so that the REF allele is coded as 0 (https://github.com/gymrek-lab/TRTools/blob/master/trtools/utils/tr_harmonizer.py#L515)
+- REF field is set to 3 (arbitrary value)
 
 analysis-runner --dataset bioheart --access-level standard --output-dir str/associatr --description "snp vcf for associatr" \
 snp_vcf_for_associatr.py --vcf-dir=gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/genotypes/vds-tenk10k1-0 \
@@ -41,7 +45,7 @@ def reformat_vcf(vcf_file_path, output_file_path):
                 fout.write('##INFO=<ID=REF,Number=1,Type=Integer,Description="">\n')
                 fout.write('##INFO=<ID=REPID,Number=1,Type=String,Description="">\n')
                 fout.write('##INFO=<ID=RL,Number=1,Type=Integer,Description="">\n')
-                fout.write('##INFO=<ID=RU,Number=1,Type=String,Description="">\n')
+                fout.write('##INFO=<ID=RU,Number=1,Type=String,Description="Storing the REF/ALT info instead of Repeat Unit to retain the REF/ALT info in the association output files, which is crucial where there are multiple variants with the same CHR:POS coordinates (eg multi allelic loci)">\n')
                 fout.write('##INFO=<ID=SVTYPE,Number=1,Type=String,Description="">\n')
                 fout.write('##INFO=<ID=VARID,Number=1,Type=String,Description="">\n')
                 fout.write('##ALT=<ID=STR1>\n')

--- a/str/associatr/helper/snp_vcf_for_associatr.py
+++ b/str/associatr/helper/snp_vcf_for_associatr.py
@@ -64,8 +64,9 @@ def reformat_vcf(vcf_file_path, output_file_path):
                 pid_index = format_field.split(':').index('PID') if 'PID' in format_field.split(':') else None
                 pid = sample_data[0].split(':')[pid_index] if pid_index is not None else '.'
 
-                # Update INFO field (add new fields required by ExpansionHunter, filler fields eg REF and RU are a constant 3)
-                new_info_fields = [f'END={parts[1]}', 'REF=3', f'REPID={pid}', 'RL=0', 'RU=3', f'VARID={pid}']
+                # Update INFO field (add new fields required by ExpansionHunter, filler fields eg REF =0)
+                # RU stores the alt_allele; this will allow us to discriminate between loci with the same POS
+                new_info_fields = [f'END={parts[1]}', 'REF=3', f'REPID={pid}', 'RL=0', f'RU={parts[4]}', f'VARID={pid}']
                 updated_info_field = ';'.join(new_info_fields)
 
                 # Update FORMAT field

--- a/str/associatr/helper/snp_vcf_for_associatr.py
+++ b/str/associatr/helper/snp_vcf_for_associatr.py
@@ -65,7 +65,7 @@ def reformat_vcf(vcf_file_path, output_file_path):
                 pid = sample_data[0].split(':')[pid_index] if pid_index is not None else '.'
 
                 # Update INFO field (add new fields required by ExpansionHunter, filler fields eg REF =0)
-                # RU stores the alt_allele; this will allow us to discriminate between loci with the same POS
+                # RU stores the ref and alt_allele; this will allow us to discriminate between loci with the same POS
                 new_info_fields = [
                     f'END={parts[1]}',
                     'REF=3',

--- a/str/associatr/helper/snp_vcf_for_associatr.py
+++ b/str/associatr/helper/snp_vcf_for_associatr.py
@@ -45,7 +45,9 @@ def reformat_vcf(vcf_file_path, output_file_path):
                 fout.write('##INFO=<ID=REF,Number=1,Type=Integer,Description="">\n')
                 fout.write('##INFO=<ID=REPID,Number=1,Type=String,Description="">\n')
                 fout.write('##INFO=<ID=RL,Number=1,Type=Integer,Description="">\n')
-                fout.write('##INFO=<ID=RU,Number=1,Type=String,Description="Storing the REF/ALT info instead of Repeat Unit to retain the REF/ALT info in the association output files, which is crucial where there are multiple variants with the same CHR:POS coordinates (eg multi allelic loci)">\n')
+                fout.write(
+                    '##INFO=<ID=RU,Number=1,Type=String,Description="Storing the REF/ALT info instead of Repeat Unit to retain the REF/ALT info in the association output files, which is crucial where there are multiple variants with the same CHR:POS coordinates (eg multi allelic loci)">\n',
+                )
                 fout.write('##INFO=<ID=SVTYPE,Number=1,Type=String,Description="">\n')
                 fout.write('##INFO=<ID=VARID,Number=1,Type=String,Description="">\n')
                 fout.write('##ALT=<ID=STR1>\n')


### PR DESCRIPTION
The current state of the script implements a dummy '3' value for "RU" for all loci. 

Here I propose adding the REF/ALT allele in into the "RU" field. 

This allows us to retain the REF/ALT info in the association output files, which is crucial where there are multiple variants with the same CHR:POS coordinates (eg multi allelic loci). 

Have tested this and runs as expected. 