### PR TITLE
Write output to analysis bucket

### DIFF
--- a/str/associatr/helper/raw_pval_extractor.py
+++ b/str/associatr/helper/raw_pval_extractor.py
@@ -37,7 +37,7 @@ def main(input_dir, cell_types, chromosomes):
     Extracts the raw p-values from the results of associaTR into one text file per cell type.
     """
     for cell_type in cell_types.split(','):
-        gcs_output = output_path(f'raw_pval_extractor/{cell_type}_gene_tests_raw_pvals.txt')
+        gcs_output = output_path(f'raw_pval_extractor/{cell_type}_gene_tests_raw_pvals.txt', 'analysis')
         with to_path(gcs_output).open('w') as f:
             for chromosome in chromosomes.split(','):
                 gene_files = list(to_path(f'{input_dir}/{cell_type}/chr{chromosome}').glob('*.tsv'))

--- a/str/associatr/meta_analysis/meta_runner.py
+++ b/str/associatr/meta_analysis/meta_runner.py
@@ -5,14 +5,14 @@ This script runs R's meta package to generate pooled effect sizes for each eQTL.
 Assumes associaTR was run previously on both cohorts and gene lists were generated for each cell type and chromosome.
 Outputs a TSV file with the meta-analysis results for each gene.
 
-analysis-runner --dataset "bioheart" --description "meta results runner" --access-level "test" \
-    --output-dir "str/associatr/tob_n1055_and_bioheart_n990/DL_random_model" \
-    meta_runner.py --results-dir-1=gs://cpg-bioheart-test/str/associatr/tob_n1055/results/v1 \
-    --results-dir-2=gs://cpg-bioheart-test/str/associatr/bioheart_n990/results/v1 \
+analysis-runner --dataset "bioheart" --description "meta results runner" --access-level "full" \
+    --output-dir "str/associatr/common_variants_snps/tob_n1055_and_bioheart_n990" \
+    meta_runner.py --results-dir-1=gs://cpg-bioheart-main-analysis/str/associatr/common_variants_snps/tob_n1055/results/v3 \
+    --results-dir-2=gs://cpg-bioheart-main-analysis/str/associatr/common_variants_snps/bioheart_n990/results/v3 \
     --gene-list-dir-1=gs://cpg-bioheart-test/str/associatr/tob_n1055/input_files/scRNA_gene_lists/1_min_pct_cells_expressed \
     --gene-list-dir-2=gs://cpg-bioheart-test/str/associatr/bioheart_n990/input_files/scRNA_gene_lists/1_min_pct_cells_expressed \
-    --cell-types=CD4_TCM \
-    --chromosomes=chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22
+    --cell-types=CD8_TEM \
+    --chromosomes=chr22
 """
 import json
 
@@ -146,7 +146,7 @@ def run_meta_gen(input_dir_1, input_dir_2, cell_type, chr, gene):
 
     # write to GCS
     pd_meta_df.to_csv(
-        f'{output_path(f"meta_results/{cell_type}/{chr}/{gene}_100000bp_meta_results.tsv")}',
+        f'{output_path(f"meta_results/{cell_type}/{chr}/{gene}_100000bp_meta_results.tsv", "analysis")}',
         sep='\t',
         index=False,
     )


### PR DESCRIPTION
Write to analysis bucket so I can plot these p-values in a GCP notebook. 

The output file is  just a list of p-values from each gene test done, so not a security risk. 