### PR TITLE
"Meta sandwich" or DF concatenator. 

### DIFF
--- a/str/associatr/meta_analysis/dataframe_concatenator.py
+++ b/str/associatr/meta_analysis/dataframe_concatenator.py
@@ -24,7 +24,7 @@ import click
 import hailtop.batch as hb
 
 from cpg_utils import to_path
-from cpg_utils.hail_batch import get_batch
+from cpg_utils.hail_batch import get_batch, output_path
 
 
 def run_concatenator(input_dir_1, input_dir_2, celltype, chromosome, gene_file):
@@ -75,7 +75,11 @@ def main(input_dir_1, input_dir_2, celltypes, chromosomes, max_parallel_jobs, al
                 # see if the gene file exists in input dir 2. If it does, concatenate the two files together.
                 file_name = gene_file.split('/')[-1]
                 if to_path(f'{input_dir_2}/{celltype}/{chromosome}/{file_name}').exists():
+                    # see if output file exists. If it does, skip this job
+                    if to_path(output_path(f'{celltype}/{chromosome}/{gene_file}', 'analysis')).exists():
+                        continue
                     j = b.new_python_job(name=f'concatenate_{celltype}_{chromosome}_{file_name}')
+                    j.cpu(0.25)
                     if always_run:
                         j.always_run()
                     j.call(run_concatenator, input_dir_1, input_dir_2, celltype, chromosome, file_name)

--- a/str/associatr/meta_analysis/dataframe_concatenator.py
+++ b/str/associatr/meta_analysis/dataframe_concatenator.py
@@ -14,7 +14,8 @@ analysis-runner --dataset "bioheart" --description "concatenate meta-analysis re
     --input-dir-1=gs://cpg-bioheart-test/str/associatr/common_variants_snps/tob_n1055_and_bioheart_n990/meta_results \
     --input-dir-2=gs://cpg-bioheart-test/str/associatr/tob_n1055_and_bioheart_n990/DL_random_model/meta_results \
     --celltypes=B_intermediate \
-    --chromosomes=chr1
+    --chromosomes=chr1 \
+    --max-parallel-jobs=10
 
 """
 
@@ -43,12 +44,12 @@ def run_concatenator(input_dir_1, input_dir_2, celltype, chromosome, gene_file):
     df.to_csv(output_path(f'{celltype}/{chromosome}/{gene_file}', 'analysis'), sep='\t', index=False)
 
 
-@click.command('--input-dir-1', help='Input directory for the first collection of dataframes')
-@click.command('--input-dir-2', help='Input directory for the second collection of dataframes')
-@click.commmand('--celltypes', help='comma-separated list of cell types')
-@click.command('--chromosomes', help='comma-separated list of chromosomes')
-@click.command('--max-parallel-jobs', help='Maximum number of jobs to run in parallel', default=500)
-@click.command('--always-run', help='Job set to always run', is_flag=True)
+@click.option('--input-dir-1', help='Input directory for the first collection of dataframes')
+@click.option('--input-dir-2', help='Input directory for the second collection of dataframes')
+@click.option('--celltypes', help='comma-separated list of cell types')
+@click.option('--chromosomes', help='comma-separated list of chromosomes')
+@click.option('--max-parallel-jobs', help='Maximum number of jobs to run in parallel', default=500)
+@click.option('--always-run', help='Job set to always run', is_flag=True)
 @click.command()
 def main(input_dir_1, input_dir_2, celltypes, chromosomes, max_parallel_jobs, always_run):
     """

--- a/str/associatr/meta_analysis/dataframe_concatenator.py
+++ b/str/associatr/meta_analysis/dataframe_concatenator.py
@@ -76,7 +76,7 @@ def main(input_dir_1, input_dir_2, celltypes, chromosomes, max_parallel_jobs, al
                 file_name = gene_file.split('/')[-1]
                 if to_path(f'{input_dir_2}/{celltype}/{chromosome}/{file_name}').exists():
                     # see if output file exists. If it does, skip this job
-                    if to_path(output_path(f'{celltype}/{chromosome}/{gene_file}', 'analysis')).exists():
+                    if to_path(output_path(f'{celltype}/{chromosome}/{file_name}', 'analysis')).exists():
                         continue
                     j = b.new_python_job(name=f'concatenate_{celltype}_{chromosome}_{file_name}')
                     j.cpu(0.25)

--- a/str/associatr/meta_analysis/dataframe_concatenator.py
+++ b/str/associatr/meta_analysis/dataframe_concatenator.py
@@ -11,10 +11,10 @@ Only common genes between the two datasets will be concatenated.
 analysis-runner --dataset "bioheart" --description "concatenate meta-analysis results" --access-level "test" \
     --output-dir "str/associatr/snps_and_strs/tob_n1055_and_bioheart_n990\meta_results" \
     dataframe_concatenator.py \
-    --input-dir-1=gs://cpg-bioheart-main-analysis/str/associatr/common_variants_snps/tob_n1055/meta_results/v3 \
-    --input-dir-2=gs://cpg-bioheart-main-analysis/str/associatr/common_variants_snps/bioheart_n990/meta_results/v3 \
-    --celltypes=CD8_TEM \
-    --chromosomes=chr22
+    --input-dir-1=gs://cpg-bioheart-test/str/associatr/common_variants_snps/tob_n1055_and_bioheart_n990/meta_results \
+    --input-dir-2=gs://cpg-bioheart-test/str/associatr/tob_n1055_and_bioheart_n990/DL_random_model/meta_results \
+    --celltypes=B_intermediate \
+    --chromosomes=chr1
 
 """
 
@@ -31,6 +31,7 @@ def run_concatenator(input_dir_1, input_dir_2, celltype, chromosome, gene_file):
     Concatenate two dataframes together.
     """
     import pandas as pd
+
     from cpg_utils.hail_batch import output_path
 
     # read input files
@@ -41,14 +42,14 @@ def run_concatenator(input_dir_1, input_dir_2, celltype, chromosome, gene_file):
     # write results as a tsv file to gcp
     df.to_csv(output_path(f'{celltype}/{chromosome}/{gene_file}', 'analysis'), sep='\t', index=False)
 
+
 @click.command('--input-dir-1', help='Input directory for the first collection of dataframes')
 @click.command('--input-dir-2', help='Input directory for the second collection of dataframes')
-@click.commmand('--celltypes', help= 'comma-separated list of cell types')
+@click.commmand('--celltypes', help='comma-separated list of cell types')
 @click.command('--chromosomes', help='comma-separated list of chromosomes')
 @click.command('--max-parallel-jobs', help='Maximum number of jobs to run in parallel', default=500)
 @click.command('--always-run', help='Job set to always run', is_flag=True)
 @click.command()
-
 def main(input_dir_1, input_dir_2, celltypes, chromosomes, max_parallel_jobs, always_run):
     """
     Runner script to concatenate two dataframes together.
@@ -80,10 +81,6 @@ def main(input_dir_1, input_dir_2, celltypes, chromosomes, max_parallel_jobs, al
                     manage_concurrency_for_job(j)
     b.run(wait=False)
 
+
 if __name__ == '__main__':
     main()
-
-
-
-
-

--- a/str/associatr/meta_analysis/dataframe_concatenator.py
+++ b/str/associatr/meta_analysis/dataframe_concatenator.py
@@ -78,7 +78,7 @@ def main(input_dir_1, input_dir_2, celltypes, chromosomes, max_parallel_jobs, al
                     j = b.new_python_job(name=f'concatenate_{celltype}_{chromosome}_{file_name}')
                     if always_run:
                         j.always_run()
-                    j.call(run_concatenator, input_dir_1, input_dir_2, celltype, chromosome, gene_file)
+                    j.call(run_concatenator, input_dir_1, input_dir_2, celltype, chromosome, file_name)
                     manage_concurrency_for_job(j)
     b.run(wait=False)
 

--- a/str/associatr/meta_analysis/dataframe_concatenator.py
+++ b/str/associatr/meta_analysis/dataframe_concatenator.py
@@ -74,7 +74,7 @@ def main(input_dir_1, input_dir_2, celltypes, chromosomes, max_parallel_jobs, al
             for gene_file in gene_files:
                 # see if the gene file exists in input dir 2. If it does, concatenate the two files together.
                 file_name = gene_file.split('/')[-1]
-                if to_path(f'{input_dir_2}/{celltype}/{chromosome}/{gene_file}').exists():
+                if to_path(f'{input_dir_2}/{celltype}/{chromosome}/{file_name}').exists():
                     j = b.new_python_job(name=f'concatenate_{celltype}_{chromosome}_{file_name}')
                     if always_run:
                         j.always_run()

--- a/str/associatr/meta_analysis/dataframe_concatenator.py
+++ b/str/associatr/meta_analysis/dataframe_concatenator.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+"""
+This script concatenates (row-wise) two dataframes together.
+Assumed that the header for the two dataframes are the same.
+Outputs results as a TSV file.
+
+This helper script will be used to concatenate the results of the meta-analysis for eSNPs and eSTRs together, with each gene having its own file.
+Only common genes between the two datasets will be concatenated.
+
+analysis-runner --dataset "bioheart" --description "concatenate meta-analysis results" --access-level "test" \
+    --output-dir "str/associatr/snps_and_strs/tob_n1055_and_bioheart_n990\meta_results" \
+    dataframe_concatenator.py \
+    --input-dir-1=gs://cpg-bioheart-main-analysis/str/associatr/common_variants_snps/tob_n1055/meta_results/v3 \
+    --input-dir-2=gs://cpg-bioheart-main-analysis/str/associatr/common_variants_snps/bioheart_n990/meta_results/v3 \
+    --celltypes=CD8_TEM \
+    --chromosomes=chr22
+
+"""
+
+import click
+
+import hailtop.batch as hb
+
+from cpg_utils import to_path
+from cpg_utils.hail_batch import get_batch
+
+
+def run_concatenator(input_dir_1, input_dir_2, celltype, chromosome, gene_file):
+    """
+    Concatenate two dataframes together.
+    """
+    import pandas as pd
+    from cpg_utils.hail_batch import output_path
+
+    # read input files
+    df1 = pd.read_csv(f'{input_dir_1}/{celltype}/{chromosome}/{gene_file}', sep='\t')
+    df2 = pd.read_csv(f'{input_dir_2}/{celltype}/{chromosome}/{gene_file}', sep='\t')
+    # concatenate
+    df = pd.concat([df1, df2], ignore_index=True)
+    # write results as a tsv file to gcp
+    df.to_csv(output_path(f'{celltype}/{chromosome}/{gene_file}', 'analysis'), sep='\t', index=False)
+
+@click.command('--input-dir-1', help='Input directory for the first collection of dataframes')
+@click.command('--input-dir-2', help='Input directory for the second collection of dataframes')
+@click.commmand('--celltypes', help= 'comma-separated list of cell types')
+@click.command('--chromosomes', help='comma-separated list of chromosomes')
+@click.command('--max-parallel-jobs', help='Maximum number of jobs to run in parallel', default=500)
+@click.command('--always-run', help='Job set to always run', is_flag=True)
+@click.command()
+
+def main(input_dir_1, input_dir_2, celltypes, chromosomes, max_parallel_jobs, always_run):
+    """
+    Runner script to concatenate two dataframes together.
+    """
+    # Setup MAX concurrency by genes
+    _dependent_jobs: list[hb.batch.job.Job] = []
+
+    def manage_concurrency_for_job(job: hb.batch.job.Job):
+        """
+        To avoid having too many jobs running at once, we have to limit concurrency.
+        """
+        if len(_dependent_jobs) >= max_parallel_jobs:
+            job.depends_on(_dependent_jobs[-max_parallel_jobs])
+        _dependent_jobs.append(job)
+
+    b = get_batch()
+    for celltype in celltypes.split(','):
+        for chromosome in chromosomes.split(','):
+            # gets the list of available gene files in input dir 1
+            gene_files = list(map(str, to_path(f'{input_dir_1}/{celltype}/{chromosome}').glob('*.tsv')))
+            for gene_file in gene_files:
+                # see if the gene file exists in input dir 2. If it does, concatenate the two files together.
+                file_name = gene_file.split('/')[-1]
+                if to_path(f'{input_dir_2}/{celltype}/{chromosome}/{gene_file}').exists():
+                    j = b.new_python_job(name=f'concatenate_{celltype}_{chromosome}_{file_name}')
+                    if always_run:
+                        j.always_run()
+                    j.call(run_concatenator, input_dir_1, input_dir_2, celltype, chromosome, gene_file)
+                    manage_concurrency_for_job(j)
+    b.run(wait=False)
+
+if __name__ == '__main__':
+    main()
+
+
+
+
+

--- a/str/associatr/meta_analysis/run_gene_level_pvals_meta.py
+++ b/str/associatr/meta_analysis/run_gene_level_pvals_meta.py
@@ -124,10 +124,12 @@ def cct(gene_files: list[str], cell_type: str, chromosome: str, og_weights=None)
         pvals, gene_name, row_dict = process_single_file(gene_file)
 
         # specify output path
-        gcs_output = to_path(output_path(
-            f'gene_level_pvals/acat/{cell_type}/chr{chromosome}/{gene_name}_gene_level_pval.tsv',
-            'analysis',
-        ))
+        gcs_output = to_path(
+            output_path(
+                f'gene_level_pvals/acat/{cell_type}/chr{chromosome}/{gene_name}_gene_level_pval.tsv',
+                'analysis',
+            )
+        )
         if gcs_output.exists():
             print(f'{gene_file} already processed. Skipping...')
             continue

--- a/str/associatr/meta_analysis/run_gene_level_pvals_meta.py
+++ b/str/associatr/meta_analysis/run_gene_level_pvals_meta.py
@@ -7,9 +7,9 @@ Assumed input files follow the format of output TSV files from meta_runner.py (i
 Output is multiple gene-specific TSV files with the gene name in the first column, and gene-level p-value in the second column.
 The attributes of the locus with the lowest raw p-value are also stored in the TSV file (coordinates, pooled _beta, pooled_se, pooled_pval,pooled_pval_q, motif, ref_len).
 
-analysis-runner --dataset "bioheart" --description "compute gene level pvals" --access-level "full" \
+analysis-runner --dataset "bioheart" --description "compute gene level pvals" --access-level "test" \
     --output-dir "str/associatr/tester/cp" \
-    run_gene_level_pvals_meta.py --input-dir=gs://cpg-bioheart-test-analysis/str/associatr/snps_and_strs/tob_n1055_and_bioheart_n990\\meta_results \
+    run_gene_level_pvals_meta.py --input-dir=gs://cpg-bioheart-test/str/associatr/snps_and_strs/tob_n1055_and_bioheart_n990\\meta_results \
     --cell-types=B_intermediate \
     --chromosomes=1 --acat
 """

--- a/str/associatr/meta_analysis/run_gene_level_pvals_meta.py
+++ b/str/associatr/meta_analysis/run_gene_level_pvals_meta.py
@@ -7,11 +7,11 @@ Assumed input files follow the format of output TSV files from meta_runner.py (i
 Output is multiple gene-specific TSV files with the gene name in the first column, and gene-level p-value in the second column.
 The attributes of the locus with the lowest raw p-value are also stored in the TSV file (coordinates, pooled _beta, pooled_se, pooled_pval,pooled_pval_q, motif, ref_len).
 
-analysis-runner --dataset "bioheart" --description "compute gene level pvals" --access-level "test" \
-    --output-dir "str/associatr/tob_n1055_and_bioheart_n990/DL_random_model/meta_results" \
-    run_gene_level_pvals_meta.py --input-dir=gs://cpg-bioheart-test/str/associatr/tob_n1055_and_bioheart_n990/DL_random_model/meta_results \
-    --cell-types=CD4_TCM \
-    --chromosomes=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 --acat
+analysis-runner --dataset "bioheart" --description "compute gene level pvals" --access-level "full" \
+    --output-dir "str/associatr/tester/cp" \
+    run_gene_level_pvals_meta.py --input-dir=gs://cpg-bioheart-test-analysis/str/associatr/snps_and_strs/tob_n1055_and_bioheart_n990\\meta_results \
+    --cell-types=B_intermediate \
+    --chromosomes=1 --acat
 """
 import logging
 from copy import deepcopy
@@ -124,10 +124,10 @@ def cct(gene_files: list[str], cell_type: str, chromosome: str, og_weights=None)
         pvals, gene_name, row_dict = process_single_file(gene_file)
 
         # specify output path
-        gcs_output = output_path(
+        gcs_output = to_path(output_path(
             f'gene_level_pvals/acat/{cell_type}/chr{chromosome}/{gene_name}_gene_level_pval.tsv',
             'analysis',
-        )
+        ))
         if gcs_output.exists():
             print(f'{gene_file} already processed. Skipping...')
             continue

--- a/str/associatr/meta_analysis/run_gene_level_pvals_meta.py
+++ b/str/associatr/meta_analysis/run_gene_level_pvals_meta.py
@@ -199,10 +199,10 @@ def bonferroni_compute(gene_files, cell_type, chromosome):
         pvals, gene_name, row_dict = process_single_file(gene_file)
 
         # write to output
-        gcs_output = output_path(
+        gcs_output = to_path(output_path(
             f'gene_level_pvals/bonferroni/{cell_type}/chr{chromosome}/{gene_name}_gene_level_pval.tsv',
             'analysis',
-        )
+        ))
         if gcs_output.exists():
             print(f'{gene_file} already processed. Skipping...')
             continue


### PR DESCRIPTION
This script concatenates (row-wise) two dataframes together.
Assumed that the header for the two dataframes are the same.
Outputs results as a TSV file.

This helper script will be used to concatenate the results of the meta-analysis for eSNPs and eSTRs together, with each gene having its own file.
Only common genes between the two datasets will be concatenated.

Batch runs: https://batch.hail.populationgenomics.org.au/batches/453262