### PR TITLE
Condition on the SNP genotype for eQTL analysis 

### DIFF
--- a/str/associatr/get_cis_numpy_files.py
+++ b/str/associatr/get_cis_numpy_files.py
@@ -203,7 +203,7 @@ def main():
                 snp_vcf_dir = get_config()['get_cis_numpy']['snp_vcf_dir']
                 snp_vcf_path = f'{snp_vcf_dir}/{chrom}_common_variants.vcf.bgz'
                 snp_input = get_batch().read_input_group(**{'vcf': snp_vcf_path, 'csi': snp_vcf_path + '.csi'})
-            else: # no SNP VCF provided
+            else:  # no SNP VCF provided
                 snp_input = None
             j.call(
                 cis_window_numpy_extractor,

--- a/str/associatr/get_cis_numpy_files.py
+++ b/str/associatr/get_cis_numpy_files.py
@@ -43,10 +43,6 @@ def extract_genotypes(vcf_file, loci):
     results = pd.DataFrame()
     results['sample_id'] = vcf_reader.samples
 
-    # Initialize results dictionary with empty lists for each locus
-    for locus in loci:
-        results[locus] = ["." for _ in vcf_reader.samples]
-
     # Iterate through the records in the VCF file for each locus
     for locus in loci:
         chrom, pos = locus.split(':')

--- a/str/associatr/get_cis_numpy_files.py
+++ b/str/associatr/get_cis_numpy_files.py
@@ -21,6 +21,7 @@ from ast import literal_eval
 import numpy as np
 import pandas as pd
 import scanpy as sc
+from cyvcf2 import VCF
 from scipy.stats import norm
 
 import hail as hl
@@ -30,7 +31,6 @@ from cpg_utils import to_path
 from cpg_utils.config import get_config
 from cpg_utils.hail_batch import get_batch, image_path, init_batch, output_path
 
-from cyvcf2 import VCF
 
 def extract_genotypes(vcf_file, loci):
     """
@@ -149,9 +149,8 @@ def cis_window_numpy_extractor(
         gene_pheno_cov = gene_pheno.merge(covariates, on='sample_id', how='inner')
 
         # add SNP genotypes we would like to condition on
-        snp_genotype_df = extract_genotypes(snp_input['vcf'],snp_loci)
+        snp_genotype_df = extract_genotypes(snp_input['vcf'], snp_loci)
         gene_pheno_cov = gene_pheno_cov.merge(snp_genotype_df, on='sample_id', how='inner')
-
 
         # filter for samples that were assigned a CPG ID; unassigned samples after demultiplexing will not have a CPG ID
         gene_pheno_cov = gene_pheno_cov[gene_pheno_cov['sample_id'].str.startswith('CPG')]

--- a/str/associatr/get_cis_numpy_files.py
+++ b/str/associatr/get_cis_numpy_files.py
@@ -156,8 +156,6 @@ def cis_window_numpy_extractor(
         # filter for samples that were assigned a CPG ID; unassigned samples after demultiplexing will not have a CPG ID
         gene_pheno_cov = gene_pheno_cov[gene_pheno_cov['sample_id'].str.startswith('CPG')]
 
-        gene_pheno_cov.to_csv(output_path(f'pheno_cov_numpy/{version}/{cell_type}/{chromosome}/{gene}_pheno_cov.csv'), index=False)
-
         gene_pheno_cov['sample_id'] = gene_pheno_cov['sample_id'].str[
             3:
         ]  # remove CPG prefix because associatr expects id to be numeric
@@ -205,7 +203,7 @@ def main():
                 snp_vcf_dir = get_config()['get_cis_numpy']['snp_vcf_dir']
                 snp_vcf_path = f'{snp_vcf_dir}/{chrom}_common_variants.vcf.bgz'
                 snp_input = get_batch().read_input_group(**{'vcf': snp_vcf_path, 'csi': snp_vcf_path + '.csi'})
-            else: # no SNP VCF provided
+            else:  # no SNP VCF provided
                 snp_input = None
             j.call(
                 cis_window_numpy_extractor,

--- a/str/associatr/get_cis_numpy_files.py
+++ b/str/associatr/get_cis_numpy_files.py
@@ -50,7 +50,9 @@ def extract_genotypes(vcf_file, loci):
 
         for record in vcf_reader(f'{chrom}:{pos}-{pos}'):
             if record.CHROM == chrom and record.POS == pos:
-                results[locus] = record.gt_types
+                gt = record.gt_types
+                gt[gt == 3] = 2 #HOM ALT is coded as 3; change it to 2
+                results[locus] = gt
                 break
 
     # Convert results to a DataFrame

--- a/str/associatr/get_cis_numpy_files.py
+++ b/str/associatr/get_cis_numpy_files.py
@@ -10,7 +10,7 @@ This script aims to:
  - output gene-level phenotype and covariate numpy objects for input into associatr
 
  analysis-runner  --config get_cis_numpy_files.toml --dataset "bioheart" --access-level "test" \
---description "get cis and numpy" --output-dir "str/associatr/tob_n1055/input_files"  \
+--description "get cis and numpy" --output-dir "str/associatr/tob_n1055/tester" \
 --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
 python3 get_cis_numpy_files.py
 
@@ -156,6 +156,8 @@ def cis_window_numpy_extractor(
         # filter for samples that were assigned a CPG ID; unassigned samples after demultiplexing will not have a CPG ID
         gene_pheno_cov = gene_pheno_cov[gene_pheno_cov['sample_id'].str.startswith('CPG')]
 
+        gene_pheno_cov.to_csv(output_path(f'pheno_cov_numpy/{version}/{cell_type}/{chromosome}/{gene}_pheno_cov.csv'), index=False)
+
         gene_pheno_cov['sample_id'] = gene_pheno_cov['sample_id'].str[
             3:
         ]  # remove CPG prefix because associatr expects id to be numeric
@@ -203,7 +205,7 @@ def main():
                 snp_vcf_dir = get_config()['get_cis_numpy']['snp_vcf_dir']
                 snp_vcf_path = f'{snp_vcf_dir}/{chrom}_common_variants.vcf.bgz'
                 snp_input = get_batch().read_input_group(**{'vcf': snp_vcf_path, 'csi': snp_vcf_path + '.csi'})
-            else:  # no SNP VCF provided
+            else: # no SNP VCF provided
                 snp_input = None
             j.call(
                 cis_window_numpy_extractor,

--- a/str/associatr/get_cis_numpy_files.py
+++ b/str/associatr/get_cis_numpy_files.py
@@ -40,8 +40,8 @@ def extract_genotypes(vcf_file, loci):
     # Read the VCF file
     vcf_reader = VCF(vcf_file)
 
-    # Initialize a dictionary to store the results
-    results = {'sample_id': vcf_reader.samples}
+    results = pd.DataFrame()
+    results['sample_id'] = vcf_reader.samples
 
     # Initialize results dictionary with empty lists for each locus
     for locus in loci:
@@ -54,21 +54,11 @@ def extract_genotypes(vcf_file, loci):
 
         for record in vcf_reader(f'{chrom}:{pos}-{pos}'):
             if record.CHROM == chrom and record.POS == pos:
-                for idx, sample in enumerate(record.genotypes):
-                    genotype_call = sample[0] + sample[1]
-                    if genotype_call == 0:
-                        genotype = "0"  # HOM REF
-                    elif genotype_call == 1:
-                        genotype = "1"  # HET
-                    elif genotype_call == 2:
-                        genotype = "2"  # HOM ALT
-                    else:
-                        genotype = "."
-                    results[locus][idx] = genotype
+                results[locus] = record.gt_types
                 break
 
     # Convert results to a DataFrame
-    return pd.DataFrame(results)
+    return results
 
 
 def cis_window_numpy_extractor(


### PR DESCRIPTION
Further workup of results require conditioning on the lead SNP genotype to see if the signal persists after we take out the SNP. 
Practically this means adding the SNP genotype for the lead SNP locus as a new covariate

This PR implements that change: 
- user can specify one or multiple target SNP loci to control for as `snp_loci` in the config toml. 
- helper method `extract_genotypes` extracts the GT for the relevant locus (0,1,2 are the only GT options) 
- This `sno_genotype_vcf` is then merged with the larger `gene_pheno_cov` (which is a larger df containing other existing covariates), based on the 'sample_id' 