### PR TITLE
use unmasked fasta for thousand-genomes too

### DIFF
--- a/str/runners/str_iterative_eh_runner.py
+++ b/str/runners/str_iterative_eh_runner.py
@@ -86,7 +86,7 @@ def main(
     b = get_batch()
 
     # Reference fasta
-    if 'hgdp' in dataset:
+    if 'hgdp' in dataset or 'thousand-genomes' in dataset:
         ref_fasta = 'gs://cpg-common-main/references/hg38/v0/Homo_sapiens_assembly38.fasta'
     else:
         ref_fasta = str(reference_path('broad/ref_fasta'))


### PR DESCRIPTION
Shannon needs to run this on 1kG, not hgdp and we encounter the checksum mismatch again when using the masked fasta. 