### PR TITLE
Corr matrix maker

### DIFF
--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -93,8 +93,8 @@ def ld_parser(
 
     # calculate pairwise correlation of every variant
     corr_matrix = merged_df.drop(columns='individual').corr()
-    corr_matrix.to_csv(f'correlation_matrix/{celltype}/{gene}_correlation_matrix.tsv', sep='\t')
-    corr_matrix.columns.to_csv(f'correlation_matrix/{celltype}/{gene}_correlation_matrix_variants.tsv', sep='\t')
+    corr_matrix.to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix.tsv', 'analysis'), sep='\t')
+    corr_matrix.columns.to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix_variants.tsv','analysis'), sep='\t')
 
     print("Wrote correlation matrix to bucket")
 

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -96,8 +96,9 @@ def ld_parser(
     print(snp_df)
 
     # calculate pairwise correlation of every variant
+    merged_df = merged_df.drop(columns='individual')
     merged_df = merged_df.fillna(merged_df.mean()) # fill missing values with mean to avoid NAs
-    corr_matrix = merged_df.drop(columns='individual').corr()
+    corr_matrix = merged_df.corr()
 
     print(corr_matrix)
     corr_matrix.to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix.tsv', 'analysis'), sep='\t')

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -94,8 +94,7 @@ def ld_parser(
     # calculate pairwise correlation of every variant
     corr_matrix = merged_df.drop(columns='individual').corr()
     corr_matrix.to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix.tsv', 'analysis'), sep='\t')
-    corr_matrix.columns.to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix_variants.tsv','analysis'), sep='\t')
-
+    pd.Series(corr_matrix.columns).to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix_variants.tsv','analysis'), sep='\t', index=False)
     print("Wrote correlation matrix to bucket")
 
 

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -12,11 +12,11 @@ For each gene,
 3) Obtain the genotypes for each extracted STR and SNP in 2)
 4) Calculate the correlation matrix between STR and SNP genotypes.
 
-association-runner --dataset "bioheart" \
+analysis-runner --dataset "bioheart" \
     --description "Calculate LD between STR and SNPs" \
     --access-level "test" \
-    --output-dir "str/associatr/fine_mapping/prep_files" \
-    ld_runner.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf\
+    --output-dir "str/associatr/fine_mapping/prep_files/test" \
+    corr_matrix_maker.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf\
     --str-vcf-dir=gs://cpg-bioheart-test/str/saige-qtl/input_files/vcf/v1-chr-specific \
     --celltypes=ASDC \
     --associatr-dir=gs://cpg-bioheart-test/str/associatr/snps_and_strs/tob_n1055_and_bioheart_n990/meta_results
@@ -153,7 +153,7 @@ def main(
         str_fdr = str_fdr[str_fdr['qval'] < fdr_cutoff]  # subset to eGenes passing FDR 5% threshold by default
         for index, row in str_fdr.iterrows():
             gene = row['gene_name']
-            chrom = ast.literal_eval(row['chr'].iloc[0])
+            chrom = ast.literal_eval(row['chr'])[0]
             # test only
             if chrom != 'chr20':
                 continue

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -56,12 +56,12 @@ def ld_parser(
         try:
             associatr_file = f'{associatr_dir}/{celltype}/{chrom}/lol/{gene}_100000bp_meta_results.tsv'
             associatr = pd.read_csv(associatr_file, sep='\t')
-        except:
-            f'FileNotFound for this gene: {gene}'
+        except FileNotFoundError:
+            print(f'FileNotFound for this gene: {gene}')
             continue
         associatr = associatr[associatr['pval_meta'] < pval_cutoff]
         if associatr.empty:
-            f'No associatr results for this gene: {gene}'
+            print(f'No associatr results for this gene: {gene}')
             continue
 
         # create empty DF to store the relevant GTs (SNPs, STRs)

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -90,9 +90,12 @@ def ld_parser(
                     break
     # merge the two dataframes
     merged_df = str_df.merge(snp_df, on='individual')
+    print(str_df)
+    print(snp_df)
 
     # calculate pairwise correlation of every variant
     corr_matrix = merged_df.drop(columns='individual').corr()
+    print(corr_matrix)
     corr_matrix.to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix.tsv', 'analysis'), sep='\t')
     pd.Series(corr_matrix.columns).to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix_variants.tsv','analysis'), sep='\t', index=False)
     print("Wrote correlation matrix to bucket")

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -175,7 +175,7 @@ def main(
             ld_job.cpu(job_cpu)
             ld_job.storage(job_storage)
             snp_input = get_batch().read_input_group(**{'vcf': snp_vcf_path, 'csi': snp_vcf_path + '.csi'})
-            str_input = get_batch().read_input_group(**{'vcf': str_vcf_path, 'csi': str_vcf_path + '.csi'})
+            str_input = get_batch().read_input_group(**{'vcf': str_vcf_path, 'csi': str_vcf_path + '.tbi'})
 
             ld_job.call(
                 ld_parser,

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -56,8 +56,8 @@ def ld_parser(
         try:
             associatr_file = f'{associatr_dir}/{celltype}/{chrom}/lol/{gene}_100000bp_meta_results.tsv'
             associatr = pd.read_csv(associatr_file, sep='\t')
-        except FileNotFoundError:
-            f'No associatr results for this gene: {gene}'
+        except:
+            f'FileNotFound for this gene: {gene}'
             continue
         associatr = associatr[associatr['pval_meta'] < pval_cutoff]
         if associatr.empty:
@@ -120,7 +120,7 @@ def ld_parser(
             output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix.tsv', 'analysis'),
             sep='\t',
         )
-        print(f"Wrote correlation matrix for{gene}")
+        print(f"Wrote correlation matrix for {gene}")
     return
 
 

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-This file is used to create a correlation matrix between STR and SNP genotypes, which is required by fine-mapping methods.
+This script is used to create a correlation matrix between STR and SNP genotypes, which is required by fine-mapping methods.
 
 Output: Correlation matrix, and list of variants (as appears in the matrix)
 
@@ -96,10 +96,11 @@ def ld_parser(
     print(snp_df)
 
     # calculate pairwise correlation of every variant
+    merged_df = merged_df.fillna(merged_df.mean()) # fill missing values with mean to avoid NAs
     corr_matrix = merged_df.drop(columns='individual').corr()
+
     print(corr_matrix)
     corr_matrix.to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix.tsv', 'analysis'), sep='\t')
-    pd.Series(corr_matrix.columns).to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix_variants.tsv','analysis'), sep='\t', index=False)
     print("Wrote correlation matrix to bucket")
 
 
@@ -149,7 +150,7 @@ def main(
     associatr_dir: str,
     pval_cutoff: float,
 ):
-    b = get_batch()
+    b = get_batch(name = 'Correlation matrix runner')
     for celltype in celltypes.split(','):
         # read in STR eGene annotation file
         str_fdr_file = f'{str_fdr_dir}/{celltype}_qval.tsv'

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -89,7 +89,7 @@ def ld_parser(
                     str_df[f'chr{chr_num}:{pos}_{motif}'] = sums
                     break
     # merge the two dataframes
-    merged_df = str_vcf.merge(snp_vcf, on='individual')
+    merged_df = str_df.merge(snp_df, on='individual')
 
     # calculate pairwise correlation of every variant
     corr_matrix = merged_df.drop(columns='individual').corr()

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -56,6 +56,8 @@ def ld_parser(
     snp_df['individual'] = snp_vcf.samples
     str_vcf = VCF(str_vcf_path['vcf'])
     str_df['individual'] = str_vcf.samples
+    str_df['individual'] = str_df['individual'].apply(lambda x: f"CPG{x}") #add CPG prefix to match SNP individual names
+
 
     for index, row in associatr_results.iterrows():
         pos = row['pos']

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -93,7 +93,9 @@ def ld_parser(
     # merge the two dataframes
     merged_df = str_df.merge(snp_df, on='individual')
     print(str_df)
+    str_df.to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_str_df.tsv', 'analysis'), sep='\t')
     print(snp_df)
+    snp_df.to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_snp_df.tsv', 'analysis'), sep='\t')
 
     # calculate pairwise correlation of every variant
     merged_df = merged_df.drop(columns='individual')

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -8,7 +8,7 @@ Output: Correlation matrix, and list of variants (as appears in the matrix)
 Workflow (for each cell type):
 1) Extract genes where the eSTR is significant (default = FDR<0.05).
 For each gene,
-2) Extract the STR and SNP coordinates where the association signal is p < 4e-4, to reduce computational burden of fine-mapper.
+2) Extract the STR and SNP coordinates where the association signal is p < 5e-4, to reduce computational burden of fine-mapper.
 3) Obtain the genotypes for each extracted STR and SNP in 2)
 4) Calculate the correlation matrix between STR and SNP genotypes.
 
@@ -19,7 +19,7 @@ analysis-runner --dataset "bioheart" \
     corr_matrix_maker.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf\
     --str-vcf-dir=gs://cpg-bioheart-test/str/associatr/input_files/vcf/v1-chr-specific \
     --celltypes=ASDC \
-    --associatr-dir=gs://cpg-bioheart-test/associatr/snps_and_strs/tob_n1055_and_bioheart_n990/meta_results \
+    --associatr-dir=gs://cpg-bioheart-test/str/associatr/snps_and_strs/tob_n1055_and_bioheart_n990/meta_results \
     --chromosomes=chr20
 
 
@@ -94,8 +94,9 @@ def ld_parser(
                     break
             else:  # STR
                 chrom = row['chr']
+                end = int(pos +row['ref_len']*row['period'])
                 for variant in str_vcf(f'{chrom}:{pos}-{pos}'):
-                    if str(variant.INFO.get('RU')) == motif: #check if the motif matches
+                    if (str(variant.INFO.get('RU')) == motif) and (int(variant.INFO.get('END'))== end): #check if the motif and end coordinate matches
                         genotypes = variant.format('REPCN')
                         # Replace '.' with '-99/-99' to handle missing values
                         genotypes = np.where(genotypes == '.', '-99/-99', genotypes)
@@ -149,7 +150,7 @@ def ld_parser(
 @click.option(
     '--pval-cutoff',
     help='P-value cutoff to use for associatr results (reduce finemapping computational burden)',
-    default=4e-4,
+    default=5e-4,
 )
 @click.option('--celltypes', help='Cell types to use for coloc', type=str)
 @click.option(

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -97,7 +97,7 @@ def ld_parser(
 
     # calculate pairwise correlation of every variant
     merged_df = merged_df.drop(columns='individual')
-    merged_df = merged_df.fillna(merged_df.mean()) # fill missing values with mean to avoid NAs
+    merged_df = merged_df.fillna(merged_df.mean(), inplace=True) # fill missing values with mean to avoid NAs
     corr_matrix = merged_df.corr()
 
     print(corr_matrix)

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -56,8 +56,9 @@ def ld_parser(
     snp_df['individual'] = snp_vcf.samples
     str_vcf = VCF(str_vcf_path['vcf'])
     str_df['individual'] = str_vcf.samples
-    str_df['individual'] = str_df['individual'].apply(lambda x: f"CPG{x}") #add CPG prefix to match SNP individual names
-
+    str_df['individual'] = str_df['individual'].apply(
+        lambda x: f"CPG{x}",
+    )  # add CPG prefix to match SNP individual names
 
     for index, row in associatr_results.iterrows():
         pos = row['pos']
@@ -92,18 +93,16 @@ def ld_parser(
                     break
     # merge the two dataframes
     merged_df = str_df.merge(snp_df, on='individual')
-    print(str_df)
-    str_df.to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_str_df.tsv', 'analysis'), sep='\t')
-    print(snp_df)
-    snp_df.to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_snp_df.tsv', 'analysis'), sep='\t')
 
     # calculate pairwise correlation of every variant
     merged_df = merged_df.drop(columns='individual')
-    merged_df = merged_df.fillna(merged_df.mean(), inplace=True) # fill missing values with mean to avoid NAs
+    merged_df = merged_df.fillna(merged_df.mean())  # fill missing values with mean to avoid NAs
     corr_matrix = merged_df.corr()
 
     print(corr_matrix)
-    corr_matrix.to_csv(output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix.tsv', 'analysis'), sep='\t')
+    corr_matrix.to_csv(
+        output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix.tsv', 'analysis'), sep='\t',
+    )
     print("Wrote correlation matrix to bucket")
 
 
@@ -153,7 +152,7 @@ def main(
     associatr_dir: str,
     pval_cutoff: float,
 ):
-    b = get_batch(name = 'Correlation matrix runner')
+    b = get_batch(name='Correlation matrix runner')
     for celltype in celltypes.split(','):
         # read in STR eGene annotation file
         str_fdr_file = f'{str_fdr_dir}/{celltype}_qval.tsv'
@@ -162,9 +161,7 @@ def main(
         for index, row in str_fdr.iterrows():
             gene = row['gene_name']
             chrom = ast.literal_eval(row['chr'])[0]
-            # test only
-            if chrom != 'chr20':
-                continue
+
             try:
                 associatr_file = f'{associatr_dir}/{celltype}/{chrom}/{gene}_100000bp_meta_results.tsv'
                 associatr = pd.read_csv(associatr_file, sep='\t')

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -54,7 +54,7 @@ def ld_parser(
         chrom = ast.literal_eval(row['chr'])[0]
 
         try:
-            associatr_file = f'{associatr_dir}/{celltype}/{chrom}/lol/{gene}_100000bp_meta_results.tsv'
+            associatr_file = f'{associatr_dir}/{celltype}/{chrom}/{gene}_100000bp_meta_results.tsv'
             associatr = pd.read_csv(associatr_file, sep='\t')
         except FileNotFoundError:
             print(f'FileNotFound for this gene: {gene}')

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+
+"""
+This file is used to create a correlation matrix between STR and SNP genotypes, which is required by fine-mapping methods.
+
+Output: Correlation matrix, and list of variants (as appears in the matrix)
+
+Workflow (for each cell type):
+1) Extract genes where the eSTR is significant (default = FDR<0.05).
+For each gene,
+2) Extract the STR and SNP coordinates where the association signal is p < 4e-4, to reduce computational burden of fine-mapper.
+3) Obtain the genotypes for each extracted STR and SNP in 2)
+4) Calculate the correlation matrix between STR and SNP genotypes.
+
+association-runner --dataset "bioheart" \
+    --description "Calculate LD between STR and SNPs" \
+    --access-level "test" \
+    --output-dir "str/associatr/fine_mapping/prep_files" \
+    ld_runner.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf\
+    --str-vcf-dir=gs://cpg-bioheart-test/str/saige-qtl/input_files/vcf/v1-chr-specific \
+    --celltypes=ASDC \
+    --associatr-dir=gs://cpg-bioheart-test/str/associatr/snps_and_strs/tob_n1055_and_bioheart_n990/meta_results
+
+
+"""
+
+import ast
+import numpy as np
+import click
+import pandas as pd
+
+from hailtop.batch import ResourceGroup
+
+from cpg_utils import to_path
+from cpg_utils.config import output_path
+from cpg_utils.hail_batch import get_batch
+
+def ld_parser(
+    snp_vcf_path: ResourceGroup,
+    str_vcf_path: ResourceGroup,
+    associatr_results: pd.DataFrame,
+    gene: str,
+    celltype: str,
+) -> str:
+    import pandas as pd
+    from cyvcf2 import VCF
+
+    # create empty DF to store the relevant GTs (SNPs, STRs)
+    snp_df = pd.DataFrame(columns=['individual'])
+    str_df = pd.DataFrame(columns=['individual'])
+
+    # cyVCF2 reads the SNP,STR VCF
+    snp_vcf = VCF(snp_vcf_path['vcf'])
+    snp_df['individual'] = snp_vcf.samples
+    str_vcf = VCF(str_vcf_path['vcf'])
+    str_df['individual'] = str_vcf.samples
+
+    for index, row in associatr_results.iterrows():
+        pos = row['pos']
+        motif = row['motif']
+        if '-' in row['motif']: # SNP
+            chr_num = row['chr'][3:]
+            for variant in snp_vcf(f'{chr_num}:{pos}-{pos}'):
+                gt = variant.gt_types
+                gt[gt == 3] = 2
+                snp_vcf[f'chr{chr_num}:{pos}_{motif}'] = gt
+                break
+        else: # STR
+            chrom = row['chr']
+            for variant in str_vcf(f'{chrom}:{pos}-{pos}'):
+                if str(variant.INFO.get('RU')) == motif:
+                    genotypes = variant.format('REPCN')
+                    # Replace '.' with '-99/-99' to handle missing values
+                    genotypes = np.where(genotypes == '.', '-99/-99', genotypes)
+
+                    # Split each element by '/'
+                    split_genotypes = [genotype.split('/') for genotype in genotypes]
+
+                    # Convert split_genotypes into a numpy array for easier manipulation
+                    split_genotypes_array = np.array(split_genotypes)
+
+                    # Convert the strings to integers and sum them row-wise
+                    sums = np.sum(split_genotypes_array.astype(int), axis=1)
+                    # set dummy -198 value to np.nan
+                    sums = np.where(sums == -198, np.nan, sums)
+
+                    str_df[f'chr{chr_num}:{pos}_{motif}'] = sums
+                    break
+    # merge the two dataframes
+    merged_df = str_vcf.merge(snp_vcf, on='individual')
+
+    # calculate pairwise correlation of every variant
+    corr_matrix = merged_df.drop(columns='individual').corr()
+    corr_matrix.to_csv(f'correlation_matrix/{celltype}/{gene}_correlation_matrix.tsv', sep='\t')
+    corr_matrix.columns.to_csv(f'correlation_matrix/{celltype}/{gene}_correlation_matrix_variants.tsv', sep='\t')
+
+    print("Wrote correlation matrix to bucket")
+
+@click.option(
+    '--snp-vcf-dir',
+    help='GCS file dir to SNP VCF files.',
+    type=str,
+)
+@click.option(
+    '--str-vcf-dir',
+    help='GCS file dir to STR VCF files.',
+    type=str,
+)
+@click.option(
+    '--fdr-cutoff',
+    help='FDR cutoff to use for eGene selection',
+    type=float,
+    default=0.05,)
+@click.option(
+    '--pval-cutoff',
+    help='P-value cutoff to use for associatr results (reduce finemapping computational burden)',
+    default=4e-4,
+)
+@click.option('--celltypes', help='Cell types to use for coloc', type=str)
+
+@click.option(
+    '--str-fdr-dir',
+    help='Path to STR FDR dir',
+    default='gs://cpg-bioheart-test/str/associatr/tob_n1055_and_bioheart_n990/DL_random_model/meta_results/fdr_qvals/using_acat',
+)
+
+@click.option('--associatr-dir', help='Path to STR-SNP associatr results', default = 'gs://cpg-bioheart-main-analysis/str/associatr/snps_and_strs/tob_n1055_and_bioheart_n990/meta_results')
+
+@click.option('--job-cpu', default=1)
+@click.option('--job-storage', default='20G')
+@click.command()
+def main(
+    snp_vcf_dir: str,
+    str_vcf_dir: str,
+    celltypes: str,
+    fdr_cutoff: float,
+    str_fdr_dir: str,
+    job_cpu: int,
+    job_storage: str,
+    associatr_dir: str,
+    pval_cutoff: float,
+):
+    b = get_batch()
+    for celltype in celltypes.split(','):
+        # read in STR eGene annotation file
+        str_fdr_file = f'{str_fdr_dir}/{celltype}_qval.tsv'
+        str_fdr = pd.read_csv(str_fdr_file, sep='\t')
+        str_fdr = str_fdr[str_fdr['qval'] < fdr_cutoff]  # subset to eGenes passing FDR 5% threshold by default
+        for index, row in str_fdr.iterrows():
+            gene = row['gene_name']
+            chrom = ast.literal_eval(row['chr'].iloc[0])
+            #test only
+            if chrom!= 'chr20':
+                continue
+            try:
+                associatr_file = f'{associatr_dir}/{celltype}/{chrom}/{gene}_100000bp_meta_results.tsv'
+                associatr = pd.read_csv(associatr_file, sep='\t')
+            except:
+                f'No associatr results for this gene: {gene}'
+                continue
+            associatr = associatr[associatr['pval_meta'] < pval_cutoff]
+            if associatr.empty:
+                f'No associatr results for this gene: {gene}'
+                continue
+            snp_vcf_path = f'{snp_vcf_dir}/{chrom}_common_variants.vcf.bgz'
+            str_vcf_path = f'{str_vcf_dir}/hail_filtered_{chrom}.vcf.bgz'
+            # run coloc
+            ld_job = b.new_python_job(
+                f'LD calc for {gene}: {celltype}',
+            )
+            ld_job.cpu(job_cpu)
+            ld_job.storage(job_storage)
+            snp_input = get_batch().read_input_group(**{'vcf': snp_vcf_path, 'csi': snp_vcf_path + '.csi'})
+            str_input = get_batch().read_input_group(**{'vcf': str_vcf_path, 'csi': str_vcf_path + '.csi'})
+
+            ld_job.call(
+                ld_parser,
+                snp_input,
+                str_input,
+                associatr,
+                gene,
+                celltype,
+            )
+
+    b.run(wait=False)
+if __name__ == '__main__':
+    main()

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -54,7 +54,7 @@ def ld_parser(
         chrom = ast.literal_eval(row['chr'])[0]
 
         try:
-            associatr_file = f'{associatr_dir}/{celltype}/{chrom}/{gene}_100000bp_meta_results.tsv'
+            associatr_file = f'{associatr_dir}/{celltype}/{chrom}/lol/{gene}_100000bp_meta_results.tsv'
             associatr = pd.read_csv(associatr_file, sep='\t')
         except FileNotFoundError:
             f'No associatr results for this gene: {gene}'
@@ -116,12 +116,11 @@ def ld_parser(
         merged_df = merged_df.fillna(merged_df.mean())  # fill missing values with mean to avoid NAs
         corr_matrix = merged_df.corr()
 
-        print(corr_matrix)
         corr_matrix.to_csv(
             output_path(f'correlation_matrix/{celltype}/{gene}_correlation_matrix.tsv', 'analysis'),
             sep='\t',
         )
-        print("Wrote correlation matrix to bucket")
+        print(f"Wrote correlation matrix for{gene}")
     return
 
 

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -19,6 +19,7 @@ analysis-runner --dataset "bioheart" \
     corr_matrix_maker.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf\
     --str-vcf-dir=gs://cpg-bioheart-test/str/associatr/input_files/vcf/v1-chr-specific \
     --celltypes=ASDC \
+    --associatr-dir=gs://cpg-bioheart-test/associatr/snps_and_strs/tob_n1055_and_bioheart_n990/meta_results \
     --chromosomes=chr20
 
 
@@ -198,7 +199,7 @@ def main(
         str_fdr = str_fdr[str_fdr['qval'] < fdr_cutoff]  # subset to eSTRs passing FDR 5% threshold by default
         for chrom in chromosomes.split(','):
             #filter eSTRs by chromosome
-            str_fdr = str_fdr[str_fdr['chr'].str.contains(chrom)]
+            str_fdr = str_fdr[str_fdr['chr'].str.contains("'"+chrom+"'")]
             # read in STR and SNP VCFs for this chromosome
             snp_vcf_path = f'{snp_vcf_dir}/{chrom}_common_variants.vcf.bgz'
             str_vcf_path = f'{str_vcf_dir}/hail_filtered_{chrom}.vcf.bgz'

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -49,6 +49,10 @@ def ld_parser(
     import pandas as pd
     from cyvcf2 import VCF
 
+    if str_fdr.empty:
+        print(f'No eSTRs for {celltype}')
+        return
+
     for index, row in str_fdr.iterrows(): #iterate over each gene
         gene = row['gene_name']
         chrom = ast.literal_eval(row['chr'])[0]
@@ -199,7 +203,7 @@ def main(
         str_fdr = str_fdr[str_fdr['qval'] < fdr_cutoff]  # subset to eSTRs passing FDR 5% threshold by default
         for chrom in chromosomes.split(','):
             #filter eSTRs by chromosome
-            str_fdr = str_fdr[str_fdr['chr'].str.contains("'"+chrom+"'")]
+            str_fdr_chrom = str_fdr[str_fdr['chr'].str.contains("'"+chrom+"'")]
             # read in STR and SNP VCFs for this chromosome
             snp_vcf_path = f'{snp_vcf_dir}/{chrom}_common_variants.vcf.bgz'
             str_vcf_path = f'{str_vcf_dir}/hail_filtered_{chrom}.vcf.bgz'
@@ -216,7 +220,7 @@ def main(
                 ld_parser,
                 snp_input,
                 str_input,
-                str_fdr,
+                str_fdr_chrom,
                 celltype,
                 pval_cutoff,
                 associatr_dir,

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -86,7 +86,7 @@ def ld_parser(
                     # set dummy -198 value to np.nan
                     sums = np.where(sums == -198, np.nan, sums)
 
-                    str_df[f'chr{chr_num}:{pos}_{motif}'] = sums
+                    str_df[f'{chrom}:{pos}_{motif}'] = sums
                     break
     # merge the two dataframes
     merged_df = str_df.merge(snp_df, on='individual')

--- a/str/fine-mapping/corr_matrix_maker.py
+++ b/str/fine-mapping/corr_matrix_maker.py
@@ -17,7 +17,7 @@ analysis-runner --dataset "bioheart" \
     --access-level "test" \
     --output-dir "str/associatr/fine_mapping/prep_files/test" \
     corr_matrix_maker.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf\
-    --str-vcf-dir=gs://cpg-bioheart-test/str/saige-qtl/input_files/vcf/v1-chr-specific \
+    --str-vcf-dir=gs://cpg-bioheart-test/str/associatr/input_files/vcf/v1-chr-specific \
     --celltypes=ASDC \
     --associatr-dir=gs://cpg-bioheart-test/str/associatr/snps_and_strs/tob_n1055_and_bioheart_n990/meta_results
 
@@ -65,7 +65,7 @@ def ld_parser(
             for variant in snp_vcf(f'{chr_num}:{pos}-{pos}'):
                 gt = variant.gt_types
                 gt[gt == 3] = 2
-                snp_vcf[f'chr{chr_num}:{pos}_{motif}'] = gt
+                snp_df[f'chr{chr_num}:{pos}_{motif}'] = gt
                 break
         else:  # STR
             chrom = row['chr']

--- a/str/fine-mapping/corr_matrix_maker_test.py
+++ b/str/fine-mapping/corr_matrix_maker_test.py
@@ -200,7 +200,7 @@ def main(
             str_vcf_path = f'{str_vcf_dir}/hail_filtered_{chrom}.vcf.bgz'
             # run LD calculation for each chrom-celltype combination
             ld_job = b.new_python_job(
-                f'LD calc for {celltype}:{chrom}',
+                f'LD calc for {celltype}:{"'"+chrom+"'"}',
             )
             ld_job.cpu(job_cpu)
             ld_job.storage(job_storage)

--- a/str/fine-mapping/corr_matrix_maker_test.py
+++ b/str/fine-mapping/corr_matrix_maker_test.py
@@ -108,7 +108,7 @@ def ld_parser(
         #merged_df = str_df.merge(snp_df, on='individual')
 
         # calculate pairwise correlation of every variant
-        #merged_df = merged_df.drop(columns='individual')
+        str_df = str_df.drop(columns='individual')
         str_df = str_df.fillna(str_df.mean())  # fill missing values with mean of the column (variant) to avoid NAs
         corr_matrix = str_df.corr()
 

--- a/str/fine-mapping/corr_matrix_maker_test.py
+++ b/str/fine-mapping/corr_matrix_maker_test.py
@@ -89,8 +89,9 @@ def ld_parser(
                 continue
             else:  # STR
                 chrom = row['chr']
+                end = int(pos +row['ref_len']*row['period'])
                 for variant in str_vcf(f'{chrom}:{pos}-{pos}'):
-                    if str(variant.INFO.get('RU')) == motif: #check if the motif matches
+                    if (str(variant.INFO.get('RU')) == motif) and (int(variant.INFO.get('END'))== end):
                         genotypes = variant.format('REPCN')
                         # Replace '.' with '-99/-99' to handle missing values
                         genotypes = np.where(genotypes == '.', '-99/-99', genotypes)

--- a/str/fine-mapping/corr_matrix_maker_test.py
+++ b/str/fine-mapping/corr_matrix_maker_test.py
@@ -49,6 +49,10 @@ def ld_parser(
     import pandas as pd
     from cyvcf2 import VCF
 
+    if str_fdr.empty:
+        print(f'No eSTRs for this celltype: {celltype}')
+        return
+
     for index, row in str_fdr.iterrows(): #iterate over each gene
         gene = row['gene_name']
         chrom = ast.literal_eval(row['chr'])[0]
@@ -194,7 +198,7 @@ def main(
         str_fdr = str_fdr[str_fdr['qval'] < fdr_cutoff]  # subset to eSTRs passing FDR 5% threshold by default
         for chrom in chromosomes.split(','):
             #filter eSTRs by chromosome
-            str_fdr = str_fdr[str_fdr['chr'].str.contains("'"+chrom+"'")]
+            str_fdr_chrom = str_fdr[str_fdr['chr'].str.contains("'"+chrom+"'")]
             # read in STR and SNP VCFs for this chromosome
             snp_vcf_path = f'{snp_vcf_dir}/{chrom}_common_variants.vcf.bgz'
             str_vcf_path = f'{str_vcf_dir}/hail_filtered_{chrom}.vcf.bgz'
@@ -211,7 +215,7 @@ def main(
                 ld_parser,
                 #snp_input,
                 str_input,
-                str_fdr,
+                str_fdr_chrom,
                 celltype,
                 pval_cutoff,
                 associatr_dir,

--- a/str/fine-mapping/corr_matrix_maker_test.py
+++ b/str/fine-mapping/corr_matrix_maker_test.py
@@ -16,7 +16,7 @@ analysis-runner --dataset "bioheart" \
     --description "Calculate LD between STR and SNPs" \
     --access-level "test" \
     --output-dir "str/associatr/fine_mapping/prep_files/test-str-only" \
-    corr_matrix_maker.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf\
+    corr_matrix_maker_test.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf\
     --str-vcf-dir=gs://cpg-bioheart-test/str/associatr/input_files/vcf/v1-chr-specific \
     --celltypes=CD4_TCM,ASDC \
     --associatr-dir=gs://cpg-bioheart-test/str/associatr/tob_n1055_and_bioheart_n990/DL_random_model/meta_results \
@@ -109,8 +109,8 @@ def ld_parser(
 
         # calculate pairwise correlation of every variant
         #merged_df = merged_df.drop(columns='individual')
-        str_vcf = str_vcf.fillna(str_vcf.mean())  # fill missing values with mean of the column (variant) to avoid NAs
-        corr_matrix = str_vcf.corr()
+        str_df = str_df.fillna(str_df.mean())  # fill missing values with mean of the column (variant) to avoid NAs
+        corr_matrix = str_df.corr()
 
         # write to bucket
         corr_matrix.to_csv(

--- a/str/fine-mapping/corr_matrix_maker_test.py
+++ b/str/fine-mapping/corr_matrix_maker_test.py
@@ -194,13 +194,13 @@ def main(
         str_fdr = str_fdr[str_fdr['qval'] < fdr_cutoff]  # subset to eSTRs passing FDR 5% threshold by default
         for chrom in chromosomes.split(','):
             #filter eSTRs by chromosome
-            str_fdr = str_fdr[str_fdr['chr'].str.contains(chrom)]
+            str_fdr = str_fdr[str_fdr['chr'].str.contains("'"+chrom+"'")]
             # read in STR and SNP VCFs for this chromosome
             snp_vcf_path = f'{snp_vcf_dir}/{chrom}_common_variants.vcf.bgz'
             str_vcf_path = f'{str_vcf_dir}/hail_filtered_{chrom}.vcf.bgz'
             # run LD calculation for each chrom-celltype combination
             ld_job = b.new_python_job(
-                f'LD calc for {celltype}:{"'"+chrom+"'"}',
+                f'LD calc for {celltype}:{chrom}',
             )
             ld_job.cpu(job_cpu)
             ld_job.storage(job_storage)

--- a/str/fine-mapping/corr_matrix_maker_test.py
+++ b/str/fine-mapping/corr_matrix_maker_test.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+
+"""
+This script is used to create a correlation matrix between STR and SNP genotypes, which is required by fine-mapping methods.
+
+Output: Correlation matrix, and list of variants (as appears in the matrix)
+
+Workflow (for each cell type):
+1) Extract genes where the eSTR is significant (default = FDR<0.05).
+For each gene,
+2) Extract the STR and SNP coordinates where the association signal is p < 4e-4, to reduce computational burden of fine-mapper.
+3) Obtain the genotypes for each extracted STR and SNP in 2)
+4) Calculate the correlation matrix between STR and SNP genotypes.
+
+analysis-runner --dataset "bioheart" \
+    --description "Calculate LD between STR and SNPs" \
+    --access-level "test" \
+    --output-dir "str/associatr/fine_mapping/prep_files/test-str-only" \
+    corr_matrix_maker.py --snp-vcf-dir=gs://cpg-bioheart-test/str/dummy_snp_vcf\
+    --str-vcf-dir=gs://cpg-bioheart-test/str/associatr/input_files/vcf/v1-chr-specific \
+    --celltypes=CD4_TCM,ASDC \
+    --associatr-dir=gs://cpg-bioheart-test/str/associatr/tob_n1055_and_bioheart_n990/DL_random_model/meta_results \
+    --chromosomes=chr1,chr2
+
+
+"""
+
+import ast
+
+import click
+import numpy as np
+import pandas as pd
+
+import hailtop.batch as hb
+from hailtop.batch import ResourceGroup
+
+from cpg_utils.config import output_path
+from cpg_utils.hail_batch import get_batch
+
+
+def ld_parser(
+    #snp_vcf_path: ResourceGroup,
+    str_vcf_path: ResourceGroup,
+    str_fdr: pd.DataFrame,
+    celltype: str,
+    pval_cutoff: float,
+    associatr_dir: str,
+) -> str:
+    import pandas as pd
+    from cyvcf2 import VCF
+
+    for index, row in str_fdr.iterrows(): #iterate over each gene
+        gene = row['gene_name']
+        chrom = ast.literal_eval(row['chr'])[0]
+        # obtain raw associaTR results for this gene
+        try:
+            associatr_file = f'{associatr_dir}/{celltype}/{chrom}/{gene}_100000bp_meta_results.tsv'
+            associatr = pd.read_csv(associatr_file, sep='\t')
+        except FileNotFoundError:
+            print(f'FileNotFound for this gene: {gene}')
+            continue
+        # apply p-value cutoff (mostly to reduce computational burden for fine-mapper later)
+        associatr = associatr[associatr['pval_meta'] < pval_cutoff]
+        if associatr.empty:
+            print(f'No associatr results for this gene: {gene}')
+            continue
+
+        # create empty DF to store the relevant GTs (SNPs, STRs)
+        #snp_df = pd.DataFrame(columns=['individual'])
+        str_df = pd.DataFrame(columns=['individual'])
+
+        # cyVCF2 reads the SNP,STR VCF
+        #snp_vcf = VCF(snp_vcf_path['vcf'])
+        #snp_df['individual'] = snp_vcf.samples
+        str_vcf = VCF(str_vcf_path['vcf'])
+        str_df['individual'] = str_vcf.samples
+        str_df['individual'] = str_df['individual'].apply(
+            lambda x: f"CPG{x}",
+        )  # add CPG prefix to match SNP individual names
+
+        for index, row in associatr.iterrows(): #obtain GTs for each STR/SNP listed in the raw associatr file
+            pos = row['pos']
+            motif = row['motif']
+            if '-' in row['motif']:  # SNP
+                continue
+            else:  # STR
+                chrom = row['chr']
+                for variant in str_vcf(f'{chrom}:{pos}-{pos}'):
+                    if str(variant.INFO.get('RU')) == motif: #check if the motif matches
+                        genotypes = variant.format('REPCN')
+                        # Replace '.' with '-99/-99' to handle missing values
+                        genotypes = np.where(genotypes == '.', '-99/-99', genotypes)
+
+                        # Split each element by '/'
+                        split_genotypes = [genotype.split('/') for genotype in genotypes]
+
+                        # Convert split_genotypes into a numpy array for easier manipulation
+                        split_genotypes_array = np.array(split_genotypes)
+
+                        # Convert the strings to integers and sum them row-wise
+                        sums = np.sum(split_genotypes_array.astype(int), axis=1)
+                        # set dummy -198 value to np.nan
+                        sums = np.where(sums == -198, np.nan, sums)
+
+                        str_df[f'{chrom}:{pos}_{motif}'] = sums
+                        break
+        # merge the two dataframes
+        #merged_df = str_df.merge(snp_df, on='individual')
+
+        # calculate pairwise correlation of every variant
+        #merged_df = merged_df.drop(columns='individual')
+        str_vcf = str_vcf.fillna(str_vcf.mean())  # fill missing values with mean of the column (variant) to avoid NAs
+        corr_matrix = str_vcf.corr()
+
+        # write to bucket
+        corr_matrix.to_csv(
+            output_path(f'correlation_matrix/{celltype}/{chrom}/{gene}_correlation_matrix.tsv', 'analysis'),
+            sep='\t',
+        )
+        print(f"Wrote correlation matrix for {gene}")
+    return
+
+
+@click.option(
+    '--snp-vcf-dir',
+    help='GCS file dir to SNP VCF files.',
+    type=str,
+)
+@click.option(
+    '--str-vcf-dir',
+    help='GCS file dir to STR VCF files.',
+    type=str,
+)
+@click.option(
+    '--fdr-cutoff',
+    help='FDR cutoff to use for eGene selection',
+    type=float,
+    default=0.05,
+)
+@click.option(
+    '--pval-cutoff',
+    help='P-value cutoff to use for associatr results (reduce finemapping computational burden)',
+    default=4e-4,
+)
+@click.option('--celltypes', help='Cell types to use for coloc', type=str)
+@click.option(
+    '--str-fdr-dir',
+    help='Path to STR FDR dir',
+    default='gs://cpg-bioheart-test/str/associatr/tob_n1055_and_bioheart_n990/DL_random_model/meta_results/fdr_qvals/using_acat',
+)
+@click.option(
+    '--associatr-dir',
+    help='Path to STR-SNP associatr results',
+    default='gs://cpg-bioheart-main-analysis/str/associatr/snps_and_strs/tob_n1055_and_bioheart_n990/meta_results',
+)
+@click.option(
+    '--chromosomes',
+    help='Chromosomes to use',
+    default='chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22',
+)
+@click.option('--job-cpu', default=1)
+@click.option('--job-storage', default='20G')
+@click.option('--max-parallel-jobs', default=22)
+@click.command()
+def main(
+    snp_vcf_dir: str,
+    str_vcf_dir: str,
+    celltypes: str,
+    fdr_cutoff: float,
+    str_fdr_dir: str,
+    job_cpu: int,
+    job_storage: str,
+    associatr_dir: str,
+    pval_cutoff: float,
+    chromosomes: str,
+    max_parallel_jobs: int,
+):
+    # Setup MAX concurrency by genes
+    _dependent_jobs: list[hb.batch.job.Job] = []
+
+    def manage_concurrency_for_job(job: hb.batch.job.Job):
+        """
+        To avoid having too many jobs running at once, we have to limit concurrency.
+        """
+        if len(_dependent_jobs) >= max_parallel_jobs:
+            job.depends_on(_dependent_jobs[-max_parallel_jobs])
+        _dependent_jobs.append(job)
+
+    b = get_batch(name='Correlation matrix runner')
+    for celltype in celltypes.split(','):
+        # read in eSTR file
+        str_fdr_file = f'{str_fdr_dir}/{celltype}_qval.tsv'
+        str_fdr = pd.read_csv(str_fdr_file, sep='\t')
+        str_fdr = str_fdr[str_fdr['qval'] < fdr_cutoff]  # subset to eSTRs passing FDR 5% threshold by default
+        for chrom in chromosomes.split(','):
+            #filter eSTRs by chromosome
+            str_fdr = str_fdr[str_fdr['chr'].str.contains(chrom)]
+            # read in STR and SNP VCFs for this chromosome
+            snp_vcf_path = f'{snp_vcf_dir}/{chrom}_common_variants.vcf.bgz'
+            str_vcf_path = f'{str_vcf_dir}/hail_filtered_{chrom}.vcf.bgz'
+            # run LD calculation for each chrom-celltype combination
+            ld_job = b.new_python_job(
+                f'LD calc for {celltype}:{chrom}',
+            )
+            ld_job.cpu(job_cpu)
+            ld_job.storage(job_storage)
+            #snp_input = get_batch().read_input_group(**{'vcf': snp_vcf_path, 'csi': snp_vcf_path + '.csi'})
+            str_input = get_batch().read_input_group(**{'vcf': str_vcf_path, 'csi': str_vcf_path + '.tbi'})
+
+            ld_job.call(
+                ld_parser,
+                #snp_input,
+                str_input,
+                str_fdr,
+                celltype,
+                pval_cutoff,
+                associatr_dir,
+            )
+            manage_concurrency_for_job(ld_job)
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This script is used to create a correlation matrix between STR and SNP genotypes, which is required by fine-mapping methods.

Output: Correlation matrix, and list of variants (as appears in the matrix)

Workflow (for each cell type):
1) Extract genes where the eSTR is significant (default = FDR<0.05).
For each gene,
2) Extract the STR and SNP coordinates where the association signal is p < 4e-4, to reduce computational burden of fine-mapper.
3) Obtain the genotypes for each extracted STR and SNP in 2)
4) Calculate the correlation matrix between STR and SNP genotypes.

Successful batch - https://batch.hail.populationgenomics.org.au/batches/455448
