### PR TITLE
Check if shard vcf exists - skip if it does

### DIFF
--- a/str/runners/str_iterative_eh_runner.py
+++ b/str/runners/str_iterative_eh_runner.py
@@ -161,7 +161,7 @@ def main(
             # per sample, run parallel jobs on each shard of the catalog
             for index, subcatalog in enumerate(catalog_files, start=1):
 
-                if to_path(output_path(f'{cpg_id}/{cpg_id}_eh_shard{index}', 'analysis')).exists():
+                if to_path(output_path(f'{cpg_id}/{cpg_id}_eh_shard{index}.vcf', 'analysis')).exists() and not output_bam_json:
                     continue
                 # ExpansionHunter job initialisation
                 eh_job = b.new_job(name=f'ExpansionHunter:{cpg_id} running  shard {index}/{len(catalog_files)}')

--- a/str/runners/str_iterative_eh_runner.py
+++ b/str/runners/str_iterative_eh_runner.py
@@ -160,6 +160,9 @@ def main(
             )
             # per sample, run parallel jobs on each shard of the catalog
             for index, subcatalog in enumerate(catalog_files, start=1):
+
+                if to_path(output_path(f'{cpg_id}/{cpg_id}_eh_shard{index}', 'analysis')).exists():
+                    continue
                 # ExpansionHunter job initialisation
                 eh_job = b.new_job(name=f'ExpansionHunter:{cpg_id} running  shard {index}/{len(catalog_files)}')
                 eh_job.image(image_path('expansionhunter_bw2'))


### PR DESCRIPTION
Jobs failing: https://batch.hail.populationgenomics.org.au/batches/518758?q=&last_job_id=50 because some need more mem resources than others. 

Need to add a check to the script to check if the shard has produced a vcf; skip if it does so it doesn't start a job to create something that already exists. 