### PR TITLE
Fixing a quirky data typing issue in the meta_runner. 

### DIFF
--- a/str/associatr/meta_analysis/meta_runner.py
+++ b/str/associatr/meta_analysis/meta_runner.py
@@ -6,13 +6,13 @@ Assumes associaTR was run previously on both cohorts and gene lists were generat
 Outputs a TSV file with the meta-analysis results for each gene.
 
 analysis-runner --dataset "tenk10k" --description "meta results runner" --access-level "test" \
-    --output-dir "str/associatr/rna_calib/tob_n950_and_bioheart_n975/pc2" \
-    meta_runner.py --results-dir-1=gs://cpg-tenk10k-test-analysis/str/associatr/rna_calib/bioheart_n975/results/results/pc2 \
-    --results-dir-2=gs://cpg-tenk10k-test-analysis/str/associatr/rna_calib/tob_n950/results/results/pc2 \
-    --gene-list-dir-1=gs://cpg-tenk10k-test/str/associatr/final_freeze/input_files/tob_n950/scRNA_gene_lists/scRNA_gene_lists/1_min_pct_cells_expressed \
-    --gene-list-dir-2=gs://cpg-tenk10k-test/str/associatr/final_freeze/input_files/bioheart_n975/scRNA_gene_lists/1_min_pct_cells_expressed/1_min_pct_cells_expressed \
-    --cell-types=CD4_TCM \
-    --chromosomes=chr1 \
+    --output-dir "str/associatr/final_freeze/tob_n950_and_bioheart_n975/meta_results/meta_with_fixed/v2" \
+    meta_runner.py --results-dir-1=gs:/cpg-tenk10k-test-analysis/str/associatr/final_freeze/bioheart_n975/results/v1 \
+    --results-dir-2=gs://cpg-tenk10k-test-analysis/str/associatr/final_freeze/tob_n950/results/v1 \
+    --gene-list-dir-1=gs://cpg-tenk10k-test/str/associatr/final_freeze/input_files/bioheart_n975/scRNA_gene_lists/1_min_pct_cells_expressed \
+    --gene-list-dir-2=gs://cpg-tenk10k-test/str/associatr/final_freeze/input_files/tob_n950/scRNA_gene_lists/1_min_pct_cells_expressed \
+    --cell-types=cDC1 \
+    --chromosomes=chr6 \
     --always-run
 """
 import json
@@ -140,8 +140,8 @@ def run_meta_gen(input_dir_1, input_dir_2, cell_type, chr, gene):
         se_meta_fixed = m.gen$seTE.fixed,
         lowerCI_meta_random = m.gen$lower.random,
         upperCI_meta_random = m.gen$upper.random,
-        r2_1 = df[i, "regression_R^2.x"],
-        r2_2 = df[i, "regression_R^2.y"],
+        r2_1 = df[i, "regression_R.2.x"],
+        r2_2 = df[i, "regression_R.2.y"],
         motif = df[i, "motif"],
         period = df[i, "period"],
         ref_len = df[i, "ref_len"],
@@ -160,7 +160,7 @@ def run_meta_gen(input_dir_1, input_dir_2, cell_type, chr, gene):
 
     # write to GCS
     pd_meta_df.to_csv(
-        f'{output_path(f"meta_results/{cell_type}/{chr}/{gene}_100000bp_meta_results.tsv", "analysis")}',
+        f'{output_path(f"{cell_type}/{chr}/{gene}_100000bp_meta_results.tsv", "analysis")}',
         sep='\t',
         index=False,
     )
@@ -215,7 +215,7 @@ def main(
             for gene in intersected_genes:
                 if to_path(
                     output_path(
-                        f"meta_results/{cell_type}/{chromosome}/{gene}_100000bp_meta_results.tsv",
+                        f"{cell_type}/{chromosome}/{gene}_100000bp_meta_results.tsv",
                         "analysis",
                     ),
                 ).exists():

--- a/str/associatr/meta_analysis/meta_runner.py
+++ b/str/associatr/meta_analysis/meta_runner.py
@@ -11,9 +11,11 @@ analysis-runner --dataset "tenk10k" --description "meta results runner" --access
     --results-dir-2=gs://cpg-tenk10k-test-analysis/str/associatr/final_freeze/tob_n950/results/v1 \
     --gene-list-dir-1=gs://cpg-tenk10k-test/str/associatr/final_freeze/input_files/bioheart_n975/scRNA_gene_lists/1_min_pct_cells_expressed/1_min_pct_cells_expressed \
     --gene-list-dir-2=gs://cpg-tenk10k-test/str/associatr/final_freeze/input_files/tob_n950/scRNA_gene_lists/scRNA_gene_lists/1_min_pct_cells_expressed \
-    --cell-types=cDC1 \
-    --chromosomes=chr6 \
-    --always-run
+    --cell-types=ASDC,B_intermediate,B_memory,B_naive,CD14_Mono,CD16_Mono,CD4_CTL,CD4_Naive,CD4_Proliferating,CD4_TCM,CD4_TEM,CD8_Naive,CD8_Proliferating,CD8_TCM,CD8_TEM,HSPC,ILC,MAIT,NK,NK_CD56bright,NK_Proliferating,Plasmablast,Treg,cDC1,cDC2,dnT,gdT,pDC \
+    --chromosomes=chr22
+    --always-runCD4_TCM_permuted
+
+
 """
 import json
 
@@ -163,7 +165,7 @@ def run_meta_gen(input_dir_1, input_dir_2, cell_type, chr, gene):
 
     # write to GCS
     pd_meta_df.to_csv(
-        f'{output_path(f"{cell_type}/{chr}/{gene}_100000bp_meta_results.tsv", "analysis")}',
+        f'{output_path(f"meta_results/{cell_type}/{chr}/{gene}_100000bp_meta_results.tsv", "analysis")}',
         sep='\t',
         index=False,
     )
@@ -218,7 +220,7 @@ def main(
             for gene in intersected_genes:
                 if to_path(
                     output_path(
-                        f"{cell_type}/{chromosome}/{gene}_100000bp_meta_results.tsv",
+                        f"meta_results/{cell_type}/{chromosome}/{gene}_100000bp_meta_results.tsv",
                         "analysis",
                     ),
                 ).exists():

--- a/str/associatr/meta_analysis/meta_runner.py
+++ b/str/associatr/meta_analysis/meta_runner.py
@@ -9,8 +9,8 @@ analysis-runner --dataset "tenk10k" --description "meta results runner" --access
     --output-dir "str/associatr/final_freeze/tob_n950_and_bioheart_n975/meta_results/meta_with_fixed/v2" \
     meta_runner.py --results-dir-1=gs:/cpg-tenk10k-test-analysis/str/associatr/final_freeze/bioheart_n975/results/v1 \
     --results-dir-2=gs://cpg-tenk10k-test-analysis/str/associatr/final_freeze/tob_n950/results/v1 \
-    --gene-list-dir-1=gs://cpg-tenk10k-test/str/associatr/final_freeze/input_files/bioheart_n975/scRNA_gene_lists/1_min_pct_cells_expressed \
-    --gene-list-dir-2=gs://cpg-tenk10k-test/str/associatr/final_freeze/input_files/tob_n950/scRNA_gene_lists/1_min_pct_cells_expressed \
+    --gene-list-dir-1=gs://cpg-tenk10k-test/str/associatr/final_freeze/input_files/bioheart_n975/scRNA_gene_lists/1_min_pct_cells_expressed/1_min_pct_cells_expressed \
+    --gene-list-dir-2=gs://cpg-tenk10k-test/str/associatr/final_freeze/input_files/tob_n950/scRNA_gene_lists/scRNA_gene_lists/1_min_pct_cells_expressed \
     --cell-types=cDC1 \
     --chromosomes=chr6 \
     --always-run
@@ -45,8 +45,8 @@ def run_meta_gen(input_dir_1, input_dir_2, cell_type, chr, gene):
     d2 = pd.read_csv(f'{input_dir_2}/{cell_type}/{chr}/{gene}_100000bp.tsv', sep='\t')
 
     # remove loci that failed to be tested in either dataset
-    d1 = d1[d1['locus_filtered'] == 'False']
-    d2 = d2[d2['locus_filtered'] == 'False']
+    d1 = d1[d1['locus_filtered'] == False]
+    d2 = d2[d2['locus_filtered'] == False]
 
     # convert to R dataframe
     with (ro.default_converter + pandas2ri.converter).context():
@@ -140,8 +140,8 @@ def run_meta_gen(input_dir_1, input_dir_2, cell_type, chr, gene):
         se_meta_fixed = m.gen$seTE.fixed,
         lowerCI_meta_random = m.gen$lower.random,
         upperCI_meta_random = m.gen$upper.random,
-        r2_1 = df[i, "regression_R.2.x"],
-        r2_2 = df[i, "regression_R.2.y"],
+        r2_1 = df[i, "regression_R^2.x"],
+        r2_2 = df[i, "regression_R^2.y"],
         motif = df[i, "motif"],
         period = df[i, "period"],
         ref_len = df[i, "ref_len"],

--- a/str/associatr/meta_analysis/meta_runner.py
+++ b/str/associatr/meta_analysis/meta_runner.py
@@ -7,7 +7,7 @@ Outputs a TSV file with the meta-analysis results for each gene.
 
 analysis-runner --dataset "tenk10k" --description "meta results runner" --access-level "test" \
     --output-dir "str/associatr/final_freeze/tob_n950_and_bioheart_n975/meta_results/meta_with_fixed/v2" \
-    meta_runner.py --results-dir-1=gs:/cpg-tenk10k-test-analysis/str/associatr/final_freeze/bioheart_n975/results/v1 \
+    meta_runner.py --results-dir-1=gs://cpg-tenk10k-test-analysis/str/associatr/final_freeze/bioheart_n975/results/v1 \
     --results-dir-2=gs://cpg-tenk10k-test-analysis/str/associatr/final_freeze/tob_n950/results/v1 \
     --gene-list-dir-1=gs://cpg-tenk10k-test/str/associatr/final_freeze/input_files/bioheart_n975/scRNA_gene_lists/1_min_pct_cells_expressed/1_min_pct_cells_expressed \
     --gene-list-dir-2=gs://cpg-tenk10k-test/str/associatr/final_freeze/input_files/tob_n950/scRNA_gene_lists/scRNA_gene_lists/1_min_pct_cells_expressed \
@@ -44,9 +44,12 @@ def run_meta_gen(input_dir_1, input_dir_2, cell_type, chr, gene):
     d1 = pd.read_csv(f'{input_dir_1}/{cell_type}/{chr}/{gene}_100000bp.tsv', sep='\t')
     d2 = pd.read_csv(f'{input_dir_2}/{cell_type}/{chr}/{gene}_100000bp.tsv', sep='\t')
 
+    d1['locus_filtered'] = d1['locus_filtered'].astype(str)
+    d2['locus_filtered'] = d2['locus_filtered'].astype(str)
+
     # remove loci that failed to be tested in either dataset
-    d1 = d1[d1['locus_filtered'] == False]
-    d2 = d2[d2['locus_filtered'] == False]
+    d1 = d1[d1['locus_filtered'] == 'False']
+    d2 = d2[d2['locus_filtered'] == 'False']
 
     # convert to R dataframe
     with (ro.default_converter + pandas2ri.converter).context():


### PR DESCRIPTION
A very small number of jobs was failing, and I found out this was due to the data type of 'locus_filtered' being set  by Python to a boolean type if all the values were True/False. 

In most input files, 'locus_filtered' is set to string because it can take on other values apart from True/False. So these jobs succeeded because downstream filtering by 'False' would occur as expected. 

So by explicitly enforcing a string type before filtering for 'False', we ensure the filtering is working as intended. 