### PR TITLE
STEP 1 of Finemap MCV workflow - get genotypes (dosages) 

### DIFF
--- a/str/fine-mapping/mcv/files_prep_dosages.py
+++ b/str/fine-mapping/mcv/files_prep_dosages.py
@@ -168,13 +168,12 @@ def main(estrs_path):
     df = df.drop_duplicates(subset=['gene_name', 'chr'])
     # sort by chromosome
     for chrom in df['chr'].unique():
-        if chrom!= 'chr1':
-            df_chr = df[df['chr'] == chrom]
+        df_chr = df[df['chr'] == chrom]
 
-            j = b.new_python_job(name=f'Prepare for {chrom}')
-            j.cpu(1)
-            j.storage('10G')
-            j.call(dosages, chrom, df_chr)
+        j = b.new_python_job(name=f'Prepare for {chrom}')
+        j.cpu(1)
+        j.storage('10G')
+        j.call(dosages, chrom, df_chr)
 
     b.run(wait=False)
 

--- a/str/fine-mapping/mcv/files_prep_dosages.py
+++ b/str/fine-mapping/mcv/files_prep_dosages.py
@@ -167,7 +167,9 @@ def main(estrs_path):
     df = pd.read_csv(estrs_path)
     df = df.drop_duplicates(subset=['gene_name', 'chr'])
     # sort by chromosome
-    for chrom in ['chr8']:
+    for chrom in ['chr1', 'chr2', 'chr3', 'chr4', 'chr5', 'chr6', 'chr7', 'chr8', 'chr9',
+                  'chr10', 'chr11', 'chr12', 'chr13', 'chr14', 'chr15', 'chr16', 'chr17',
+                  'chr18', 'chr19', 'chr20', 'chr21', 'chr22']:
         df_chr = df[df['chr'] == chrom]
 
         j = b.new_python_job(name=f'Prepare for {chrom}')

--- a/str/fine-mapping/mcv/files_prep_dosages.py
+++ b/str/fine-mapping/mcv/files_prep_dosages.py
@@ -14,7 +14,7 @@ import pandas as pd
 from cpg_utils import to_path
 
 
-def tr_extract_genotype_matrix(chrom, start, end,vcf):
+def tr_extract_genotype_matrix(chrom, start, end,tr_file):
     """
     Extracts the genotype matrix for tandem repeats from a VCF file.
     (summed repeats)
@@ -23,7 +23,8 @@ def tr_extract_genotype_matrix(chrom, start, end,vcf):
     from cyvcf2 import VCF
     import pandas as pd
 
-
+    # Load the VCF file
+    vcf = VCF(tr_file)
 
     region = f"{chrom}:{start}-{end}"
     samples = vcf.samples
@@ -59,14 +60,16 @@ def tr_extract_genotype_matrix(chrom, start, end,vcf):
     return df
 
 
-def snp_extract_genotype_matrix(chrom, start, end,vcf):
+def snp_extract_genotype_matrix(chrom, start, end,snp_file):
     """
     Extracts the genotype matrix for SNPs from a VCF file.
 
     """
 
     import pandas as pd
-
+    from cyvcf2 import VCF
+    # Load the VCF file
+    vcf = VCF(snp_file)
     region = f"{chrom}:{start}-{end}"
     samples = vcf.samples
     genotype_dict = {sample: {} for sample in samples}
@@ -152,8 +155,8 @@ def dosages(chrom,df_chr):
         start_body = max(0, start - 100_000)
 
         # Extract genotype matrices for tandem repeats and SNPs
-        tr_df = tr_extract_genotype_matrix(chrom, start_body, end,tr_vcf)
-        snp_df = snp_extract_genotype_matrix(chrom, start_body, end,snp_vcf)
+        tr_df = tr_extract_genotype_matrix(chrom, start_body, end,local_tr_file)
+        snp_df = snp_extract_genotype_matrix(chrom, start_body, end,local_snp_file)
 
         # Merge the two genotype dfs together
         variant_df = tr_df.merge(snp_df)

--- a/str/fine-mapping/mcv/files_prep_dosages.py
+++ b/str/fine-mapping/mcv/files_prep_dosages.py
@@ -174,7 +174,7 @@ def main(estrs_path):
     df = df.drop_duplicates(subset=['gene_name', 'chr'])
     # sort by chromosome
     for chrom in df['chr'].unique():
-        df_chr = df[df['chr'] == 'chr22']
+        df_chr = df[df['chr'] == chrom]
 
         j = b.new_python_job(name=f'Prepare for {chrom}')
         j.cpu(1)

--- a/str/fine-mapping/mcv/files_prep_dosages.py
+++ b/str/fine-mapping/mcv/files_prep_dosages.py
@@ -167,9 +167,7 @@ def main(estrs_path):
     df = pd.read_csv(estrs_path)
     df = df.drop_duplicates(subset=['gene_name', 'chr'])
     # sort by chromosome
-    for chrom in ['chr1', 'chr2', 'chr3', 'chr4', 'chr5', 'chr6', 'chr7', 'chr8', 'chr9',
-                  'chr10', 'chr11', 'chr12', 'chr13', 'chr14', 'chr15', 'chr16', 'chr17',
-                  'chr18', 'chr19', 'chr20', 'chr21', 'chr22']:
+    for chrom in df['chr'].unique():
         df_chr = df[df['chr'] == chrom]
 
         j = b.new_python_job(name=f'Prepare for {chrom}')

--- a/str/fine-mapping/mcv/files_prep_dosages.py
+++ b/str/fine-mapping/mcv/files_prep_dosages.py
@@ -171,7 +171,7 @@ def main(estrs_path):
         df_chr = df[df['chr'] == chrom]
 
         j = b.new_python_job(name=f'Prepare for {chrom}')
-        j.cpu(1)
+        j.cpu(2)
         j.storage('10G')
         j.call(dosages, chrom, df_chr)
 

--- a/str/fine-mapping/mcv/files_prep_dosages.py
+++ b/str/fine-mapping/mcv/files_prep_dosages.py
@@ -177,6 +177,7 @@ def main(estrs_path):
         j.cpu(1)
         j.storage('10G')
         j.call(dosages, chrom, df_chr)
+        break
     b.run(wait=False)
 
 

--- a/str/fine-mapping/mcv/files_prep_dosages.py
+++ b/str/fine-mapping/mcv/files_prep_dosages.py
@@ -14,7 +14,7 @@ import pandas as pd
 from cpg_utils import to_path
 
 
-def tr_extract_genotype_matrix(chrom, start, end):
+def tr_extract_genotype_matrix(chrom, start, end,vcf):
     """
     Extracts the genotype matrix for tandem repeats from a VCF file.
     (summed repeats)
@@ -23,20 +23,7 @@ def tr_extract_genotype_matrix(chrom, start, end):
     from cyvcf2 import VCF
     import pandas as pd
 
-    local_file = 'local.vcf.bgz'
-    local_file_index = 'local.vcf.bgz.tbi'
 
-    tr_file = to_path(
-        f'gs://cpg-bioheart-test/tenk10k/str/associatr/final-freeze/input_files/tr_vcf/v1-chr-specific/hail_filtered_{chrom}.vcf.bgz'
-    )
-    tr_file_index = to_path(
-        f'gs://cpg-bioheart-test/tenk10k/str/associatr/final-freeze/input_files/tr_vcf/v1-chr-specific/hail_filtered_{chrom}.vcf.bgz.tbi'
-    )
-
-    tr_file.copy(local_file)
-    tr_file_index.copy(local_file_index)
-
-    vcf = VCF(local_file)
 
     region = f"{chrom}:{start}-{end}"
     samples = vcf.samples
@@ -72,28 +59,14 @@ def tr_extract_genotype_matrix(chrom, start, end):
     return df
 
 
-def snp_extract_genotype_matrix(chrom, start, end):
+def snp_extract_genotype_matrix(chrom, start, end,vcf):
     """
     Extracts the genotype matrix for SNPs from a VCF file.
 
     """
-    from cyvcf2 import VCF
+
     import pandas as pd
 
-    local_file = 'local.vcf.bgz'
-    local_file_index = 'local.vcf.bgz.tbi'
-
-    snp_file = to_path(
-        f'gs://cpg-bioheart-test/tenk10k/str/associatr/common_variant_snps/hail_filtered_{chrom}.vcf.bgz'
-    )
-    snp_file_index = to_path(
-        f'gs://cpg-bioheart-test/tenk10k/str/associatr/common_variant_snps/hail_filtered_{chrom}.vcf.bgz.tbi'
-    )
-
-    snp_file.copy(local_file)
-    snp_file_index.copy(local_file_index)
-
-    vcf = VCF(local_file)
     region = f"{chrom}:{start}-{end}"
     samples = vcf.samples
     genotype_dict = {sample: {} for sample in samples}
@@ -122,34 +95,72 @@ def snp_extract_genotype_matrix(chrom, start, end):
     return df
 
 
-def dosages(gene):
+def dosages(chrom,df_chr):
     import pandas as pd
     import numpy as np
     from cpg_utils.hail_batch import output_path
-
+    from cyvcf2 import VCF
     """
     Extracts the dosage files for each gene in the df DataFrame.
     """ ""
 
     # Load metadata to extract the window around the gene
     gene_info = pd.read_csv('gs://cpg-bioheart-test/tenk10k/saige-qtl/300libraries_n1925_adata_raw_var.csv')
-    gene_ensg = gene
-    gene_info_filtered = gene_info[gene_info['gene_ids'] == gene_ensg]
-    chrom = gene_info_filtered.iloc[0]['chr']
-    start = int(gene_info_filtered.iloc[0]['start'])
-    end = int(gene_info_filtered.iloc[0]['end']) + 100_000
-    start_body = max(0, start - 100_000)
 
-    # Extract genotype matrices for tandem repeats and SNPs
-    tr_df = tr_extract_genotype_matrix(chrom, start_body, end)
-    snp_df = snp_extract_genotype_matrix(chrom, start_body, end)
+    # Load in the SNP
 
-    # Merge the two genotype dfs together
-    variant_df = tr_df.merge(snp_df)
-    variant_df['sample'] = variant_df['sample'].astype(float)
+    local_snp_file = 'local.snp.vcf.bgz'
+    local_snp_file_index = 'local.snp.vcf.bgz.tbi'
 
-    # Save file
-    variant_df.to_csv(output_path(f"dosages/{gene_ensg}_dosages.csv"), header=True)
+    snp_file = to_path(
+        f'gs://cpg-bioheart-test/tenk10k/str/associatr/common_variant_snps/hail_filtered_{chrom}.vcf.bgz'
+    )
+    snp_file_index = to_path(
+        f'gs://cpg-bioheart-test/tenk10k/str/associatr/common_variant_snps/hail_filtered_{chrom}.vcf.bgz.tbi'
+    )
+
+    snp_file.copy(local_snp_file)
+    snp_file_index.copy(local_snp_file_index)
+    snp_vcf = VCF(local_snp_file)
+
+    # Load in the TR VCFs
+    local_tr_file = 'local.tr.vcf.bgz'
+    local_tr_file_index = 'local.tr.vcf.bgz.tbi'
+
+    tr_file = to_path(
+        f'gs://cpg-bioheart-test/tenk10k/str/associatr/final-freeze/input_files/tr_vcf/v1-chr-specific/hail_filtered_{chrom}.vcf.bgz'
+    )
+    tr_file_index = to_path(
+        f'gs://cpg-bioheart-test/tenk10k/str/associatr/final-freeze/input_files/tr_vcf/v1-chr-specific/hail_filtered_{chrom}.vcf.bgz.tbi'
+    )
+
+    tr_file.copy(local_tr_file)
+    tr_file_index.copy(local_tr_file_index)
+
+    tr_vcf = VCF(local_tr_file)
+
+    for gene in df_chr['gene_name'].unique():
+        if to_path(output_path(f'dosages/{chrom}/{gene}_dosages.csv')).exists():
+            print(f"Dosage file for {gene} already exists, skipping.")
+            continue
+
+        gene_ensg = gene
+        gene_info_filtered = gene_info[gene_info['gene_ids'] == gene_ensg]
+        chrom = gene_info_filtered.iloc[0]['chr']
+        start = int(gene_info_filtered.iloc[0]['start'])
+        end = int(gene_info_filtered.iloc[0]['end']) + 100_000
+        start_body = max(0, start - 100_000)
+
+        # Extract genotype matrices for tandem repeats and SNPs
+        tr_df = tr_extract_genotype_matrix(chrom, start_body, end,tr_vcf)
+        snp_df = snp_extract_genotype_matrix(chrom, start_body, end,snp_vcf)
+
+        # Merge the two genotype dfs together
+        variant_df = tr_df.merge(snp_df)
+        variant_df['sample'] = variant_df['sample'].astype(float)
+
+        # Save file
+        variant_df.to_csv(output_path(f"dosages/{chrom}/{gene_ensg}_dosages.csv"), header=True)
 
 
 @click.option('--estrs-path', type=str, required=True, help='Path to the estrs file.')
@@ -160,15 +171,12 @@ def main(estrs_path):
     df = df.drop_duplicates(subset=['gene_name', 'chr'])
     # sort by chromosome
     for chrom in df['chr'].unique():
-        df_chr = df[df['chr'] == chrom]
-        for gene in df_chr['gene_name'].unique():
-            if to_path(output_path(f'dosages/{gene}_dosages.csv')).exists():
-                print(f"Dosage file for {gene} already exists, skipping.")
-                continue
-            j = b.new_python_job(name=f'Prepare for {chrom} and {gene}')
-            j.cpu(1)
-            j.storage('10G')
-            j.call(dosages, gene)
+        df_chr = df[df['chr'] == 'chr22']
+
+        j = b.new_python_job(name=f'Prepare for {chrom}')
+        j.cpu(1)
+        j.storage('10G')
+        j.call(dosages, chrom, df_chr)
     b.run(wait=False)
 
 

--- a/str/fine-mapping/mcv/files_prep_dosages.py
+++ b/str/fine-mapping/mcv/files_prep_dosages.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+
+"""
+This script prepares the GT dosages files for input into files_prep_residualizer.py
+
+analysis-runner --dataset tenk10k --access-level test --memory 8G --description "Dosages file prep" --output-dir str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files \
+files_prep_dosages.py --estrs-path=gs://cpg-tenk10k-test/str/associatr/final_freeze/meta_fixed/cell-type-spec/estrs.csv
+
+"""
+
+import click
+from cpg_utils.hail_batch import get_batch, output_path
+import pandas as pd
+from cpg_utils import to_path
+
+
+def tr_extract_genotype_matrix(chrom, start, end):
+    """
+    Extracts the genotype matrix for tandem repeats from a VCF file.
+    (summed repeats)
+    """
+
+    from cyvcf2 import VCF
+    import pandas as pd
+
+    local_file = 'local.vcf.bgz'
+    local_file_index = 'local.vcf.bgz.tbi'
+
+    tr_file = to_path(
+        f'gs://cpg-bioheart-test/tenk10k/str/associatr/final-freeze/input_files/tr_vcf/v1-chr-specific/hail_filtered_{chrom}.vcf.bgz'
+    )
+    tr_file_index = to_path(
+        f'gs://cpg-bioheart-test/tenk10k/str/associatr/final-freeze/input_files/tr_vcf/v1-chr-specific/hail_filtered_{chrom}.vcf.bgz.tbi'
+    )
+
+    tr_file.copy(local_file)
+    tr_file_index.copy(local_file_index)
+
+    vcf = VCF(local_file)
+
+    region = f"{chrom}:{start}-{end}"
+    samples = vcf.samples
+    genotype_dict = {sample: {} for sample in samples}
+
+    for variant in vcf(region):
+        coord = f"{variant.CHROM}:{variant.POS}:{variant.INFO.get('RU')}"
+        repcn_data = variant.format('REPCN')  # array of strings like "10/12"
+
+        if repcn_data is None:
+            continue  # skip if field missing
+
+        for i, sample in enumerate(samples):
+            val = repcn_data[i]
+            try:
+                if isinstance(val, bytes):
+                    val = val.decode()
+
+                if val in {"./.", ".", ""}:
+                    summed = None
+                else:
+                    allele_1, allele_2 = map(int, val.split('/'))
+                    summed = allele_1 + allele_2
+            except Exception:
+                summed = None
+
+            genotype_dict[sample][coord] = summed
+
+    df = pd.DataFrame.from_dict(genotype_dict, orient='index')
+    df.index.name = "sample"
+    df.sort_index(axis=1, inplace=True)
+    df.reset_index(inplace=True)
+    return df
+
+
+def snp_extract_genotype_matrix(chrom, start, end):
+    """
+    Extracts the genotype matrix for SNPs from a VCF file.
+
+    """
+    from cyvcf2 import VCF
+    import pandas as pd
+
+    local_file = 'local.vcf.bgz'
+    local_file_index = 'local.vcf.bgz.tbi'
+
+    snp_file = to_path(
+        f'gs://cpg-bioheart-test/tenk10k/str/associatr/common_variant_snps/hail_filtered_{chrom}.vcf.bgz'
+    )
+    snp_file_index = to_path(
+        f'gs://cpg-bioheart-test/tenk10k/str/associatr/common_variant_snps/hail_filtered_{chrom}.vcf.bgz.tbi'
+    )
+
+    snp_file.copy(local_file)
+    snp_file_index.copy(local_file_index)
+
+    vcf = VCF(local_file)
+    region = f"{chrom}:{start}-{end}"
+    samples = vcf.samples
+    genotype_dict = {sample: {} for sample in samples}
+
+    for variant in vcf(region):
+        coord = f"{variant.CHROM}:{variant.POS}:{variant.INFO.get('RU')}" # e.g., "chr1:123456:A-T"
+        gt_data = variant.genotypes  # shape: (n_samples, 3)
+
+        for i, sample in enumerate(samples):
+            try:
+                allele_1, allele_2, phased = gt_data[i]  # example: [0, 1, True]
+                # Ignore phased for dosage purposes
+                if allele_1 is None or allele_2 is None:
+                    summed = None
+                else:
+                    summed = allele_1 + allele_2 #summed GT in SNP context is number of non-REF alleles
+            except Exception:
+                summed = None
+
+            genotype_dict[sample][coord] = summed
+
+    df = pd.DataFrame.from_dict(genotype_dict, orient='index')
+    df.index.name = "sample"
+    df.sort_index(axis=1, inplace=True)
+    df.reset_index(inplace=True)
+    return df
+
+
+def dosages(gene):
+    import pandas as pd
+    import numpy as np
+    from cpg_utils.hail_batch import output_path
+
+    """
+    Extracts the dosage files for each gene in the df DataFrame.
+    """ ""
+
+    # Load metadata to extract the window around the gene
+    gene_info = pd.read_csv('gs://cpg-bioheart-test/tenk10k/saige-qtl/300libraries_n1925_adata_raw_var.csv')
+    gene_ensg = gene
+    gene_info_filtered = gene_info[gene_info['gene_ids'] == gene_ensg]
+    chrom = gene_info_filtered.iloc[0]['chr']
+    start = int(gene_info_filtered.iloc[0]['start'])
+    end = int(gene_info_filtered.iloc[0]['end']) + 100_000
+    start_body = max(0, start - 100_000)
+
+    # Extract genotype matrices for tandem repeats and SNPs
+    tr_df = tr_extract_genotype_matrix(chrom, start_body, end)
+    snp_df = snp_extract_genotype_matrix(chrom, start_body, end)
+
+    # Merge the two genotype dfs together
+    variant_df = tr_df.merge(snp_df)
+    variant_df['sample'] = variant_df['sample'].astype(float)
+
+    # Save file
+    variant_df.to_csv(output_path(f"dosages/{gene_ensg}_dosages.csv"), header=True)
+
+
+@click.option('--estrs-path', type=str, required=True, help='Path to the estrs file.')
+@click.command()
+def main(estrs_path):
+    b = get_batch(name='Dosages files prep for SuSie MCV')
+    df = pd.read_csv(estrs_path)
+    df = df.drop_duplicates(subset=['gene_name', 'chr'])
+    # sort by chromosome
+    for chrom in df['chr'].unique():
+        df_chr = df[df['chr'] == chrom]
+        for gene in df_chr['gene_name'].unique():
+            if to_path(output_path(f'dosages/{gene}_dosages.csv')).exists():
+                print(f"Dosage file for {gene} already exists, skipping.")
+                continue
+            j = b.new_python_job(name=f'Prepare for {chrom} and {gene}')
+            j.cpu(1)
+            j.storage('10G')
+            j.call(dosages, gene)
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/str/fine-mapping/mcv/files_prep_dosages.py
+++ b/str/fine-mapping/mcv/files_prep_dosages.py
@@ -167,7 +167,7 @@ def main(estrs_path):
     df = pd.read_csv(estrs_path)
     df = df.drop_duplicates(subset=['gene_name', 'chr'])
     # sort by chromosome
-    for chrom in df['chr'].unique():
+    for chrom in ['chr8']:
         df_chr = df[df['chr'] == chrom]
 
         j = b.new_python_job(name=f'Prepare for {chrom}')


### PR DESCRIPTION
This is the first step of the finemapping workflow. 

For every gene associated with an eTR (TR eQTL): 

- we extract the cis window (searchspace of variants), which is +/- 100kb of the gene body. 
- then we call on helper functions `tr_extract_genotype_matrix` and `snp_extract_genotype_matrix` to extract the GTs of TR and SNP variants respectively in the cis window. 
- the TR and SNP genotype matrices (or DFs) are merged, and outputted. 
- GT output files will be used in the next step of the workflow. 

Pretty confident this works OK. 