### PR TITLE
STEP 2 of finemapping MCV workflow - residualize Xs and Ys. 

### DIFF
--- a/str/fine-mapping/mcv/files_prep_residualizer.py
+++ b/str/fine-mapping/mcv/files_prep_residualizer.py
@@ -4,7 +4,7 @@
 This script prepares the X and Y residualized files for SuSiE multiple causal variant assumption mapping.
 
 analysis-runner --dataset tenk10k --access-level test --memory 8G --description "Residualized files prep for SuSie MCV" --output-dir str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files/residualized \
-files_prep_residualizer.py --estrs-path=gs://cpg-tenk10k-test/str/associatr/final_freeze/meta_fixed/cell-type-spec/estrs.csv
+files_prep_residualizer.py --estrs-path=gs://cpg-tenk10k-test/str/associatr/final_freeze/meta_fixed/cell-type-spec/estrs.csv --chromosomes=chr1
 """
 
 import click
@@ -147,16 +147,15 @@ def residualizer(df_cell, chrom,cell_type):
         y_resid_combined.to_csv(output_path(f"{cell_type}/{chrom}/{gene_ensg}_{cell_type}_meta_cleaned_y_resid.csv"), header=True)
         X_resid_combined.to_csv(output_path(f"{cell_type}/{chrom}/{gene_ensg}_{cell_type}_meta_cleaned_X_resid.csv"))
 
-
+@click.option('--chromosomes', type=str, required=True, help='Chromosome to process.')
 @click.option('--estrs-path', type=str, required=True, help='Path to the estrs file.')
 @click.command()
-def main(estrs_path):
+def main(estrs_path,chromosomes):
     b = get_batch(name='Residualized files prep for SuSie MCV')
     df = pd.read_csv(estrs_path)
-    df = df[(df['cell_type']== 'CD4_TCM') & (df['chr'] == 'chr1')]  # Filter for a specific cell type and chromosome
     df = df.drop_duplicates(subset=['cell_type', 'gene_name', 'chr'])
     # sort by chromosome
-    for chrom in df['chr'].unique():
+    for chrom in chromosomes.split(','):
         df_chr = df[df['chr'] == chrom]
         for cell_type in df_chr['cell_type'].unique():
             df_cell = df_chr[df_chr['cell_type'] == cell_type]

--- a/str/fine-mapping/mcv/files_prep_residualizer.py
+++ b/str/fine-mapping/mcv/files_prep_residualizer.py
@@ -153,6 +153,7 @@ def residualizer(df_cell, chrom,cell_type):
 def main(estrs_path):
     b = get_batch(name='Residualized files prep for SuSie MCV')
     df = pd.read_csv(estrs_path)
+    df = df[(df['cell_type']== 'CD4_TCM') & (df['chr'] == 'chr1')]  # Filter for a specific cell type and chromosome
     df = df.drop_duplicates(subset=['cell_type', 'gene_name', 'chr'])
     # sort by chromosome
     for chrom in df['chr'].unique():

--- a/str/fine-mapping/mcv/files_prep_residualizer.py
+++ b/str/fine-mapping/mcv/files_prep_residualizer.py
@@ -4,7 +4,7 @@
 This script prepares the X and Y residualized files for SuSiE multiple causal variant assumption mapping.
 
 analysis-runner --dataset tenk10k --access-level test --memory 8G --description "Residualized files prep for SuSie MCV" --output-dir str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files/residualized \
-files_prep_residualizer.py --estrs-path=gs://cpg-tenk10k-test/str/associatr/final_freeze/meta_fixed/cell-type-spec/estrs.csv --chromosomes=chr1
+files_prep_residualizer.py --estrs-path=gs://cpg-tenk10k-test/str/associatr/final_freeze/meta_fixed/cell-type-spec/estrs.csv --chromosomes=chr21
 """
 
 import click
@@ -119,7 +119,7 @@ def residualizer(df_cell, chrom,cell_type):
 
         # === LOAD VARIANT DOSAGES ===
         variant_df = pd.read_csv(
-            f'gs://cpg-bioheart-test/tenk10k/str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files/dosages/{gene_ensg}_dosages.csv'
+            f'gs://cpg-tenk10k-test/str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files/dosages/{chrom}/{gene_ensg}_dosages.csv'
         )
         variant_df['sample'] = 'CPG' + variant_df['sample'].astype(int).astype(str)
 

--- a/str/fine-mapping/mcv/files_prep_residualizer.py
+++ b/str/fine-mapping/mcv/files_prep_residualizer.py
@@ -4,7 +4,7 @@
 This script prepares the X and Y residualized files for SuSiE multiple causal variant assumption mapping.
 
 analysis-runner --dataset tenk10k --access-level test --memory 8G --description "Residualized files prep for SuSie MCV" --output-dir str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files/residualized \
-files_prep_residualizer.py --estrs-path=gs://cpg-tenk10k-test/str/associatr/final_freeze/meta_fixed/cell-type-spec/estrs.csv --chromosomes=chr20
+files_prep_residualizer.py --estrs-path=gs://cpg-tenk10k-test/str/associatr/final_freeze/meta_fixed/cell-type-spec/estrs.csv --chromosomes=chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19
 """
 
 import click
@@ -160,9 +160,9 @@ def main(estrs_path,chromosomes):
         for cell_type in df_chr['cell_type'].unique():
             df_cell = df_chr[df_chr['cell_type'] == cell_type]
             # Split df_cell into batches of 30 rows
-            num_batches = math.ceil(len(df_cell) / 30)
+            num_batches = math.ceil(len(df_cell) / 70)
             for i in range(num_batches):
-                df_batch = df_cell.iloc[i*30 : (i+1)*30]
+                df_batch = df_cell.iloc[i*70 : (i+1)*70]
                 j = b.new_python_job(f'Prepare for {cell_type} {chrom} batch {i}')
                 j.cpu(0.25)
                 j.storage('5G')

--- a/str/fine-mapping/mcv/files_prep_residualizer.py
+++ b/str/fine-mapping/mcv/files_prep_residualizer.py
@@ -3,17 +3,16 @@
 """
 This script prepares the X and Y residualized files for SuSiE multiple causal variant assumption mapping.
 
-analysis-runner --dataset tenk10k --access-level test --memory 8G --description "Residualized files prep for SuSie MCV" --output-dir str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files \
+analysis-runner --dataset tenk10k --access-level test --memory 8G --description "Residualized files prep for SuSie MCV" --output-dir str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files/residualized \
 files_prep_residualizer.py --estrs-path=gs://cpg-tenk10k-test/str/associatr/final_freeze/meta_fixed/cell-type-spec/estrs.csv
 """
 
 import click
-from cpg_utils.hail_batch import get_batch, output_path
+from cpg_utils.hail_batch import get_batch
 import pandas as pd
-from cpg_utils import to_path
 
 
-def process_cohort_wide(variant_df, ycov1, ycov2, cell_type):
+def process_cohort_wide(variant_df, ycov, cell_type):
     """
     Aligns phenotype/covariate numpy array with variant_df,
     residualizes both y and X with respect to covariates,
@@ -34,18 +33,12 @@ def process_cohort_wide(variant_df, ycov1, ycov2, cell_type):
 
     # STEP 1: Create a df based on pseudobulk phenotype values; and joint cohort genotype PCs and RNA PCs; age and sex
 
-    # pull out sample_id and phenotype (pseudobulk value from ycov) from TOB and BioHEART each (dimensions are the same)
-
-    # start with the first cohort.
-    n_covariates = ycov1.shape[1] - 2
+    # pull out sample_id and phenotype (pseudobulk value from ycov)
+    n_covariates = ycov.shape[1] - 2
     ycov_columns = ['sample_id', 'phenotype'] + [f'covar{i+1}' for i in range(n_covariates)]
-    ycov_df_1 = pd.DataFrame(ycov1, columns=ycov_columns)
-    ycov_df_1 = ycov_df_1[['sample_id', 'phenotype']]
-    # repeat for the second cohort
-    ycov_df_2 = pd.DataFrame(ycov2, columns=ycov_columns)
-    ycov_df_2 = ycov_df_2[['sample_id', 'phenotype']]
-    # concatenate the two cohorts
-    ycov_df = pd.concat([ycov_df_1, ycov_df_2], ignore_index=True)
+    ycov_df = pd.DataFrame(ycov, columns=ycov_columns)
+    ycov_df = ycov_df[['sample_id', 'phenotype']]
+
     ycov_df['sample_id'] = 'CPG' + ycov_df['sample_id'].astype(int).astype(str)
 
     # pull out sample_id, age, sex, and first 12 geno PCs
@@ -54,7 +47,7 @@ def process_cohort_wide(variant_df, ycov1, ycov2, cell_type):
     )
     wide_pcs = wide_pcs.iloc[:, :15]
 
-    # pull out sample_id and first 6 RNA PCs of the relevant clel type
+    # pull out sample_id and first 6 RNA PCs of the relevant cell type
     rna_pcs = pd.read_csv(
         f'gs://cpg-tenk10k-test/str/pseudobulk_finemap_mcv/n1925/rna_pcs/covariates/10_rna_pcs/{cell_type}_covariates.csv'
     )
@@ -107,55 +100,52 @@ def process_cohort_wide(variant_df, ycov1, ycov2, cell_type):
     return y_resid_series, X_resid_df
 
 
-def residualizer(gene_name, cell_type):
+def residualizer(df_cell, chrom,cell_type):
+
+    """
+    Residualizes the phenotype and genotype data for genes in a given cell type and chromosome.
+    """
+
+
     from cpg_utils import to_path
     import pandas as pd
     import numpy as np
     from cpg_utils.hail_batch import output_path
 
-    # === LOAD metadata ===
-    gene_info = pd.read_csv('gs://cpg-bioheart-test/tenk10k/saige-qtl/300libraries_n1925_adata_raw_var.csv')
+    for gene in df_cell['gene_name'].unique():
+        if to_path(output_path(f"{cell_type}/{chrom}/{gene}_{cell_type}_meta_cleaned_y_resid.csv")).exists():
+            continue
+        gene_ensg = gene
 
-    gene_ensg = gene_name
-    gene_info_filtered = gene_info[gene_info['gene_ids'] == gene_ensg]
-    chrom = gene_info_filtered.iloc[0]['chr']
-
-    # === LOAD VARIANT DOSAGES ===
-    variant_df = pd.read_csv(
-        f'gs://cpg-bioheart-test/tenk10k/str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files/dosages/{gene_ensg}_dosages.csv'
-    )
-    variant_df['sample'] = 'CPG' + variant_df['sample'].astype(int).astype(str)
-
-    # === REMOVE INDELS THAT LOOK LIKE TRs === # (keeping TR-looking indels can mess up fine-mapping when comparing their signal with the TR)
-    meta = pd.read_csv(
-        f'gs://cpg-tenk10k-test-analysis/str/associatr/final_freeze/tob_n950_and_bioheart_n975/trs_snps/rm_str_indels_dup_strs_v3/{cell_type}/{chrom}/{gene_ensg}_100000bp_meta_results.tsv',
-        sep='\t',
-    )  # a bit of a hack - this file contains summary stats for a list of variants where TR-looking indels and duplicate TRs have been removed.
-    meta['variant_id'] = meta['chr'].astype(str) + ':' + meta['pos'].astype(str) + ':' + meta['motif'].astype(str)
-    columns_to_keep = ['sample'] + [col for col in variant_df.columns if col in meta['variant_id'].values]
-    variant_df = variant_df[columns_to_keep]
-
-    # === Load in bioheart data ===
-    ycov_1 = np.load(
-        to_path(
-            f'gs://cpg-bioheart-test/tenk10k/str/associatr/final_freeze/input_files/bioheart_n975/pheno_cov_numpy/v1/{cell_type}/{chrom}/{gene_ensg}_pheno_cov.npy'
+        # === LOAD VARIANT DOSAGES ===
+        variant_df = pd.read_csv(
+            f'gs://cpg-bioheart-test/tenk10k/str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files/dosages/{gene_ensg}_dosages.csv'
         )
-    )
-    # === Load in TOB data ===
-    ycov_2 = np.load(
-        to_path(
-            f'gs://cpg-bioheart-test/tenk10k/str/associatr/final_freeze/input_files/tob_n950/pheno_cov_numpy/v1/{cell_type}/{chrom}/{gene_ensg}_pheno_cov.npy'
-        )
-    )
-    y_resid_combined, X_resid_combined = process_cohort_wide(variant_df, ycov_1, ycov_2, cell_type)
+        variant_df['sample'] = 'CPG' + variant_df['sample'].astype(int).astype(str)
 
-    # Sort by sample ID just in case
-    y_resid_combined = y_resid_combined.sort_index()
-    X_resid_combined = X_resid_combined.sort_index()
+        # === REMOVE INDELS THAT LOOK LIKE TRs === # (keeping TR-looking indels can mess up fine-mapping when comparing their signal with the TR)
+        meta = pd.read_csv(
+            f'gs://cpg-tenk10k-test-analysis/str/associatr/final_freeze/tob_n950_and_bioheart_n975/trs_snps/rm_str_indels_dup_strs_v3/{cell_type}/{chrom}/{gene_ensg}_100000bp_meta_results.tsv',
+            sep='\t',
+        )  # a bit of a hack - this file contains summary stats for a list of variants where TR-looking indels and duplicate TRs have been removed.
+        meta['variant_id'] = meta['chr'].astype(str) + ':' + meta['pos'].astype(str) + ':' + meta['motif'].astype(str)
+        columns_to_keep = ['sample'] + [col for col in variant_df.columns if col in meta['variant_id'].values]
+        variant_df = variant_df[columns_to_keep]
 
-    # Save files
-    y_resid_combined.to_csv(output_path(f"{gene_ensg}_{cell_type}_meta_cleaned_y_resid.csv"), header=True)
-    X_resid_combined.to_csv(output_path(f"{gene_ensg}_{cell_type}_meta_cleaned_X_resid.csv"))
+        ycov = np.load(
+            to_path(
+                f'gs://cpg-tenk10k-test/str/pseudobulk_finemap_mcv/n1925/pheno_cov_numpy/n1925/{cell_type}/{chrom}/{gene_ensg}_pheno_cov.npy'
+            ))
+
+        y_resid_combined, X_resid_combined = process_cohort_wide(variant_df, ycov, cell_type)
+
+        # Sort by sample ID just in case
+        y_resid_combined = y_resid_combined.sort_index()
+        X_resid_combined = X_resid_combined.sort_index()
+
+        # Save files
+        y_resid_combined.to_csv(output_path(f"{cell_type}/{chrom}/{gene_ensg}_{cell_type}_meta_cleaned_y_resid.csv"), header=True)
+        X_resid_combined.to_csv(output_path(f"{cell_type}/{chrom}/{gene_ensg}_{cell_type}_meta_cleaned_X_resid.csv"))
 
 
 @click.option('--estrs-path', type=str, required=True, help='Path to the estrs file.')
@@ -169,13 +159,11 @@ def main(estrs_path):
         df_chr = df[df['chr'] == chrom]
         for cell_type in df_chr['cell_type'].unique():
             df_cell = df_chr[df_chr['cell_type'] == cell_type]
-            for gene in df_cell['gene_name'].unique():
-                if to_path(output_path(f"{gene}_{cell_type}_meta_cleaned_y_resid.csv")).exists():
-                    continue
-                j = b.new_python_job(f'Prepare for {cell_type} {chrom}: {gene}')
-                j.cpu(0.25)
-                j.storage('5G')
-                j.call(residualizer, gene, cell_type)
+            j = b.new_python_job(f'Prepare for {cell_type} {chrom}')
+            j.cpu(0.25)
+            j.storage('5G')
+            j.call(residualizer, df_cell, chrom, cell_type)
+
     b.run(wait=False)
 
 

--- a/str/fine-mapping/mcv/files_prep_residualizer.py
+++ b/str/fine-mapping/mcv/files_prep_residualizer.py
@@ -4,7 +4,7 @@
 This script prepares the X and Y residualized files for SuSiE multiple causal variant assumption mapping.
 
 analysis-runner --dataset tenk10k --access-level test --memory 8G --description "Residualized files prep for SuSie MCV" --output-dir str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files/residualized \
-files_prep_residualizer.py --estrs-path=gs://cpg-tenk10k-test/str/associatr/final_freeze/meta_fixed/cell-type-spec/estrs.csv --chromosomes=chr20
+files_prep_residualizer.py --estrs-path=gs://cpg-tenk10k-test/str/associatr/final_freeze/meta_fixed/cell-type-spec/estrs.csv --chromosomes=chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22 --job-cpu=1
 """
 
 import click
@@ -153,8 +153,9 @@ def residualizer(df_cell, chrom,cell_type):
 
 @click.option('--chromosomes', type=str, required=True, help='Chromosome to process.')
 @click.option('--estrs-path', type=str, required=True, help='Path to the estrs file.')
+@click.option('--job-cpu', type=float, default=0.25, help='CPU allocation for each job.')
 @click.command()
-def main(estrs_path,chromosomes):
+def main(estrs_path,chromosomes,job_cpu):
     b = get_batch(name='Residualized files prep for SuSie MCV')
     df = pd.read_csv(estrs_path)
     df = df.drop_duplicates(subset=['cell_type', 'gene_name', 'chr'])
@@ -168,7 +169,7 @@ def main(estrs_path,chromosomes):
             for i in range(num_batches):
                 df_batch = df_cell.iloc[i*70 : (i+1)*70]
                 j = b.new_python_job(f'Prepare for {cell_type} {chrom} batch {i}')
-                j.cpu(0.25)
+                j.cpu(job_cpu)
                 j.storage('5G')
                 j.call(residualizer, df_batch, chrom, cell_type)
 

--- a/str/fine-mapping/mcv/files_prep_residualizer.py
+++ b/str/fine-mapping/mcv/files_prep_residualizer.py
@@ -113,7 +113,7 @@ def residualizer(df_cell, chrom,cell_type):
     from cpg_utils.hail_batch import output_path
 
     for gene in df_cell['gene_name'].unique():
-        if to_path(output_path(f"{cell_type}/{chrom}/{gene}_{cell_type}_meta_cleaned_y_resid.csv")).exists():
+        if to_path(output_path(f"{cell_type}/{chrom}/{gene}_{cell_type}_meta_cleaned_X_resid.csv")).exists():
             continue
         gene_ensg = gene
 

--- a/str/fine-mapping/mcv/files_prep_residualizer.py
+++ b/str/fine-mapping/mcv/files_prep_residualizer.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+
+"""
+This script prepares the X and Y residualized files for SuSiE multiple causal variant assumption mapping.
+
+analysis-runner --dataset tenk10k --access-level test --memory 8G --description "Residualized files prep for SuSie MCV" --output-dir str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files \
+files_prep_residualizer.py --estrs-path=gs://cpg-tenk10k-test/str/associatr/final_freeze/meta_fixed/cell-type-spec/estrs.csv
+"""
+
+import click
+from cpg_utils.hail_batch import get_batch, output_path
+import pandas as pd
+from cpg_utils import to_path
+
+
+def process_cohort_wide(variant_df, ycov, gene_ensg, cell_type):
+    """
+    Aligns phenotype/covariate numpy array with variant_df,
+    residualizes both y and X with respect to covariates,
+    and returns residualized phenotype and genotype matrix.
+
+    Parameters:
+    - variant_df: pandas DataFrame with 'sample' column and variant columns
+    - ycov: numpy array with columns: sample_id, phenotype, covariates
+    - gene_ensg: string (used only for naming, can be optional)
+
+    Returns:
+    - y_resid_series: pandas Series (sample-indexed residualized phenotype)
+    - X_resid_df: pandas DataFrame (sample-indexed residualized genotypes)
+    """
+    import pandas as pd
+    import numpy as np
+    import statsmodels.api as sm
+
+    # STEP 1: Create a df based on pseudobulk phenotype values; and joint cohort genotype PCs and RNA PCs; age and sex
+
+    # pull out sample_id and phenotype (pseudobulk value from ycov)
+    n_covariates = ycov.shape[1] - 2
+    ycov_columns = ['sample_id', 'phenotype'] + [f'covar{i+1}' for i in range(n_covariates)]
+    ycov_df = pd.DataFrame(ycov, columns=ycov_columns)
+    ycov_df = ycov_df[['sample_id', 'phenotype']]
+    ycov_df['sample_id'] = 'CPG' + ycov_df['sample_id'].astype(int).astype(str)
+
+    # pull out sample_id, age, sex, and first 12 geno PCs
+    wide_pcs = pd.read_csv(
+        'gs://cpg-tenk10k-test-analysis/saige-qtl/tenk10k-genome-2-3-eur/input_files/241210/covariates/sex_age_geno_pcs_shuffled_ids_tob_bioheart.csv'
+    )
+    wide_pcs = wide_pcs.iloc[:, :15]
+
+    # pull out sample_id and first 6 RNA PCs of the relevant clel type
+    rna_pcs = pd.read_csv(
+        f'gs://cpg-tenk10k-test/str/pseudobulk_finemap_mcv/n1925/rna_pcs/covariates/10_rna_pcs/{cell_type}_covariates.csv'
+    )
+    rna_pcs = rna_pcs.iloc[:, :7]
+
+    # sequential merging
+    ycov_df = ycov_df.merge(wide_pcs)
+    ycov_df = ycov_df.merge(rna_pcs)
+    ycov_df = ycov_df.rename(columns={'sample_id': 'sample'})
+
+    # --------------------
+    # STEP 2: Merge on sample_id to align
+    # --------------------
+    merged = pd.merge(variant_df, ycov_df, on='sample', how='inner')
+
+    # --------------------
+    # STEP 3: Extract and mean-impute X (missing GTs will not work.)
+    # --------------------
+    variant_cols = variant_df.columns.drop('sample')
+    X = merged[variant_cols].copy()
+    X_imputed = X.apply(lambda col: col.fillna(col.mean()), axis=0).values
+
+    # Extract y and covariates
+    y = merged['phenotype'].values
+    cols = [col for col in ycov_df.columns if col not in ['sample', 'phenotype', 'sample_id']]
+
+    C = merged[cols].values  # covariates only
+
+    # --------------------
+    # STEP 4: Residualize y and X
+    # --------------------
+    C = sm.add_constant(C)
+
+    # Residualize phenotype
+    model_y = sm.OLS(y, C).fit()
+    y_resid = model_y.resid
+
+    # Residualize each variant (the X's)
+    X_resid = np.empty_like(X_imputed)
+    for j in range(X_imputed.shape[1]):
+        model = sm.OLS(X_imputed[:, j], C).fit()
+        X_resid[:, j] = model.resid
+
+    # --------------------
+    # STEP 5: Output residualized data
+    # --------------------
+    y_resid_series = pd.Series(y_resid, index=merged['sample'], name='phenotype_resid')
+    X_resid_df = pd.DataFrame(X_resid, columns=variant_cols, index=merged['sample'])
+
+    return y_resid_series, X_resid_df
+
+
+def residualizer(gene_name, cell_type):
+    from cpg_utils import to_path
+    import pandas as pd
+    import numpy as np
+    from cpg_utils.hail_batch import output_path
+
+    # === LOAD metadata ===
+    gene_info = pd.read_csv('gs://cpg-bioheart-test/tenk10k/saige-qtl/300libraries_n1925_adata_raw_var.csv')
+
+    gene_ensg = gene_name
+    gene_info_filtered = gene_info[gene_info['gene_ids'] == gene_ensg]
+    chrom = gene_info_filtered.iloc[0]['chr']
+
+    # === LOAD VARIANT DOSAGES ===
+    variant_df = pd.read_csv(
+        f'gs://cpg-bioheart-test/tenk10k/str/associatr/final_freeze/fine_mapping/susie_mcv/prep_files/dosages/{gene_ensg}_dosages.csv'
+    )
+    variant_df['sample'] = 'CPG' + variant_df['sample'].astype(int).astype(str)
+
+    # === REMOVE INDELS THAT LOOK LIKE TRs === # (keeping TR-looking indels can mess up fine-mapping when comparing their signal with the TR)
+    meta = pd.read_csv(
+        f'gs://cpg-tenk10k-test-analysis/str/associatr/final_freeze/tob_n950_and_bioheart_n975/trs_snps/rm_str_indels_dup_strs_v3/{cell_type}/{chrom}/{gene_ensg}_100000bp_meta_results.tsv',
+        sep='\t',
+    )  # a bit of a hack - this file contains summary stats for a list of variants where TR-looking indels and duplicate TRs have been removed.
+    meta['variant_id'] = meta['chr'].astype(str) + ':' + meta['pos'].astype(str) + ':' + meta['motif'].astype(str)
+    columns_to_keep = ['sample'] + [col for col in variant_df.columns if col in meta['variant_id'].values]
+    variant_df = variant_df[columns_to_keep]
+
+    # === Load in bioheart data ===
+    ycov_1 = np.load(
+        to_path(
+            f'gs://cpg-bioheart-test/tenk10k/str/associatr/final_freeze/input_files/bioheart_n975/pheno_cov_numpy/v1/{cell_type}/{chrom}/{gene_ensg}_pheno_cov.npy'
+        )
+    )
+    y_resid_1, X_resid_1 = process_cohort_wide(variant_df, ycov_1, gene_ensg, cell_type)
+
+    # === Load in TOB data ===
+    ycov_2 = np.load(
+        to_path(
+            f'gs://cpg-bioheart-test/tenk10k/str/associatr/final_freeze/input_files/tob_n950/pheno_cov_numpy/v1/{cell_type}/{chrom}/{gene_ensg}_pheno_cov.npy'
+        )
+    )
+    y_resid_2, X_resid_2 = process_cohort_wide(variant_df, ycov_2, gene_ensg, cell_type)
+
+    # === STACK & EXPORT ===
+    y_resid_combined = pd.concat([y_resid_1, y_resid_2])
+    X_resid_combined = pd.concat([X_resid_1, X_resid_2])
+
+    # Sort by sample ID just in case
+    y_resid_combined = y_resid_combined.sort_index()
+    X_resid_combined = X_resid_combined.sort_index()
+
+    # Save files
+    y_resid_combined.to_csv(output_path(f"{gene_ensg}_{cell_type}_meta_cleaned_y_resid.csv"), header=True)
+    X_resid_combined.to_csv(output_path(f"{gene_ensg}_{cell_type}_meta_cleaned_X_resid.csv"))
+
+
+@click.option('--estrs-path', type=str, required=True, help='Path to the estrs file.')
+@click.command()
+def main(estrs_path):
+    b = get_batch(name='Residualized files prep for SuSie MCV')
+    df = pd.read_csv(estrs_path)
+    df = df.drop_duplicates(subset=['cell_type', 'gene_name', 'chr'])
+    # sort by chromosome
+    for chrom in df['chr'].unique():
+        df_chr = df[df['chr'] == chrom]
+        for cell_type in df_chr['cell_type'].unique():
+            df_cell = df_chr[df_chr['cell_type'] == cell_type]
+            for gene in df_cell['gene_name'].unique():
+                if to_path(output_path(f"{gene}_{cell_type}_meta_cleaned_y_resid.csv")).exists():
+                    continue
+                j = b.new_python_job(f'Prepare for {cell_type} {chrom}: {gene}')
+                j.cpu(0.25)
+                j.storage('5G')
+                j.call(residualizer, gene, cell_type)
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/str/fine-mapping/mcv/files_prep_residualizer.py
+++ b/str/fine-mapping/mcv/files_prep_residualizer.py
@@ -82,15 +82,14 @@ def process_cohort_wide(variant_df, ycov, cell_type):
     # --------------------
     C = sm.add_constant(C)
 
-    # Residualize phenotype
-    model_y = sm.OLS(y, C).fit()
-    y_resid = model_y.resid
+    # Compute hat matrix: H = C @ (CᵗC)⁻¹ @ Cᵗ
+    H = C @ np.linalg.inv(C.T @ C) @ C.T
 
-    # Residualize each variant (the X's)
-    X_resid = np.empty_like(X_imputed)
-    for j in range(X_imputed.shape[1]):
-        model = sm.OLS(X_imputed[:, j], C).fit()
-        X_resid[:, j] = model.resid
+    # Residualize phenotype
+    y_resid = y - H @ y
+
+    # Residualized X: X_resid = (I - H) @ X
+    X_resid = X_imputed - H @ X_imputed
 
     # --------------------
     # STEP 5: Output residualized data

--- a/str/fine-mapping/mcv/files_prep_residualizer.py
+++ b/str/fine-mapping/mcv/files_prep_residualizer.py
@@ -163,11 +163,11 @@ def main(estrs_path,chromosomes):
             # Split df_cell into batches of 30 rows
             num_batches = math.ceil(len(df_cell) / 30)
             for i in range(num_batches):
-                df_batch = df_cell.iloc[i*70 : (i+1)*30]
+                df_batch = df_cell.iloc[i*30 : (i+1)*30]
                 j = b.new_python_job(f'Prepare for {cell_type} {chrom} batch {i}')
                 j.cpu(0.25)
                 j.storage('5G')
-                j.call(residualizer, df_batch, chrom, cell_type, i)
+                j.call(residualizer, df_batch, chrom, cell_type)
 
     b.run(wait=False)
 


### PR DESCRIPTION
This is the second step of the finemapping workflow, last step before we actually run SuSIE. 

SuSIE inputs require the phenotype (y) and x(genotypes) to have all covariates regressed out. Therefore, this step is called `files_prep_residualizer.py`.  X (genotypes) are derived from the dosages file created in step 1. 

Covariates we want to regress out are: 12 WGS (SNP) PCs, 6 RNA PCs (specific to the cell type), and age, sex. This step is done in `process_cohort_wide()` helper function. 

Output are the X and Y residuals as two dfs that are written to GCS for each unique gene x cell type combination. 

The data is stored as: 
- the phenotype (y) is stored in separate npy arrays for tob and bioheart. This is why we have to load them separately.
- We derive the 12 WGS SNP PCs, age, and sex from a pre-existing covariates file used for SAIGE (contains data for both TOB and BioHEART). 
- We derive the 6 RNA PCs from a separate cell type-specific file (contains data for both TOB and BioHEART). 

Please do a logic review of `process_cohort_wide()` helper function. 
Susie docs on regressing out the covariates - https://stephenslab.github.io/susieR/articles/finemapping.html#a-note-on-covariate-adjustment