### PR TITLE
Identify proximal ATAC peaks

### DIFF
--- a/str/README.md
+++ b/str/README.md
@@ -67,7 +67,7 @@ Finally, combine eSTR and eSNP associaTR results using [`dataframe_concatenator.
 - Run [`master_cell_spec_runner.py`](https://github.com/populationgenomics/sv-workflows/blob/main/str/cell-type-spec/master_cell_spec_runner.py) to produce output CSV file of cell type specific scores for each sc-eQTL. Assumes the first two scripts above have run.
 
 ### Cell state inference
-- Pseudobulk and z-test comparisons scripts are found in [`cell-state`](https://https://github.com/populationgenomics/sv-workflows/tree/main/str/cell-state).
+- Pseudobulk and z-test comparisons scripts are found in [`cell-state`](https://github.com/populationgenomics/sv-workflows/tree/main/str/cell-state).
 
 ### Finemapping (`fine-mapping`) with SuSIE (multiple causal variant assumption)
 

--- a/tenk10k-sv/atac/get_sv_proximal_peaks.py
+++ b/tenk10k-sv/atac/get_sv_proximal_peaks.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# pylint: disable=too-many-locals
+
+"""
+This script aims to:
+ - identify the ATAC-seq peaks ('loc' column of PseudobulkMatStandardised.csv) that fall within
+   a window (default 1Mb) of any SV in a VCF, per cell type.
+ - output {cell_type}_loc.csv (a single 'loc' column), which is the format expected by the
+   loc_filtered_dir input of str/atac/get_cis_numpy.py.
+
+SV coordinates are taken as POS to INFO/END; SVs without an END (eg BND, INS) are treated as
+POS to POS. A peak is retained if it overlaps [POS - window_size, END + window_size].
+
+analysis-runner --config get_sv_proximal_peaks.toml --dataset "bioheart" --access-level "test" \
+--description "get SV-proximal ATAC peaks" --output-dir "str/atac-seq/sv-proximal-peaks/1mb" \
+python3 get_sv_proximal_peaks.py
+
+"""
+
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import get_batch, image_path, output_path
+
+
+def sv_proximal_loc_extractor(
+    sv_intervals_file,
+    pseudobulk_dir,
+    cell_type,
+    window_size,
+):
+    """
+    Writes the subset of peaks lying within window_size of an SV to {cell_type}_loc.csv
+
+    """
+    import numpy as np
+    import pandas as pd
+
+    from cpg_utils.hail_batch import output_path
+
+    def strip_chr(series):
+        # the pseudobulk matrices use 'chr1', so normalise both sides rather than assume the VCF matches
+        return series.astype(str).str.replace('^chr', '', regex=True)
+
+    svs = pd.read_csv(sv_intervals_file, sep='\t', names=['chrom', 'pos', 'end'], dtype=str)
+    svs['pos'] = svs['pos'].astype(int)
+    # bcftools writes '.' when INFO/END is absent
+    svs['end'] = pd.to_numeric(svs['end'], errors='coerce').fillna(svs['pos']).astype(int)
+    svs['chrom'] = strip_chr(svs['chrom'])
+    print(f'Read {svs.shape[0]} SVs across {svs["chrom"].nunique()} contigs')
+
+    peaks = pd.read_csv(f'{pseudobulk_dir}/{cell_type}/PseudobulkMatStandardised.csv', usecols=['loc'])
+    coords = peaks['loc'].astype(str).str.extract(r'^(?P<chrom>[^:]+):(?P<start>\d+)-(?P<end>\d+)$')
+    unparsed = coords['chrom'].isna().sum()
+    if unparsed:
+        print(f'WARNING: dropping {unparsed} peaks whose loc could not be parsed as chrom:start-end')
+    peaks = peaks.assign(
+        chrom=strip_chr(coords['chrom']),
+        start=pd.to_numeric(coords['start']),
+        end=pd.to_numeric(coords['end']),
+    ).dropna(subset=['start', 'end'])
+    print(f'Read {peaks.shape[0]} peaks for {cell_type}')
+
+    shared_contigs = set(peaks['chrom']) & set(svs['chrom'])
+    if not shared_contigs:
+        raise ValueError(
+            f'No contigs shared between the SV VCF and the {cell_type} peaks - check chromosome naming. '
+            f'SV contigs: {sorted(set(svs["chrom"]))[:5]}, peak contigs: {sorted(set(peaks["chrom"]))[:5]}',
+        )
+
+    retained = []
+    for chrom, chrom_peaks in peaks.groupby('chrom'):
+        chrom_svs = svs[svs['chrom'] == chrom]
+        if chrom_svs.empty:
+            continue
+
+        window_starts = np.maximum(chrom_svs['pos'].to_numpy() - window_size, 0)
+        window_ends = chrom_svs['end'].to_numpy() + window_size
+        order = np.argsort(window_starts)
+        window_starts, window_ends = window_starts[order], window_ends[order]
+
+        # merge the windows into disjoint intervals so each peak can be tested with a single lookup
+        merged_starts: list[int] = []
+        merged_ends: list[int] = []
+        for start, end in zip(window_starts, window_ends):
+            if merged_ends and start <= merged_ends[-1]:
+                merged_ends[-1] = max(merged_ends[-1], end)
+            else:
+                merged_starts.append(start)
+                merged_ends.append(end)
+        merged_starts_arr = np.array(merged_starts)
+        merged_ends_arr = np.array(merged_ends)
+
+        peak_starts = chrom_peaks['start'].to_numpy()
+        peak_ends = chrom_peaks['end'].to_numpy()
+        # the last window starting at or before the peak end is the only one that can overlap
+        idx = np.searchsorted(merged_starts_arr, peak_ends, side='right') - 1
+        overlaps = (idx >= 0) & (merged_ends_arr[np.clip(idx, 0, None)] >= peak_starts)
+        retained.append(chrom_peaks[overlaps])
+
+    proximal = pd.concat(retained) if retained else peaks.iloc[:0]
+    print(
+        f'{cell_type}: {proximal.shape[0]} of {peaks.shape[0]} peaks '
+        f'({100 * proximal.shape[0] / max(peaks.shape[0], 1):.1f}%) within {window_size}bp of an SV',
+    )
+
+    proximal[['loc']].to_csv(output_path(f'{cell_type}_loc.csv'), index=False)
+
+
+def main():
+    """
+    Extract SV intervals once, then identify SV-proximal peaks per cell type
+    """
+    b = get_batch(name='get SV-proximal ATAC peaks')
+    config = get_config()['get_sv_proximal_peaks']
+
+    # pull CHROM/POS/END out of the VCF once, so the per-cell-type jobs only handle a small table
+    extract_job = b.new_job(name='Extract SV intervals')
+    extract_job.image(image_path('bcftools'))
+    extract_job.storage(config['extract_job_storage'])
+    vcf = b.read_input(config['sv_vcf_path'])
+    extract_job.command(
+        f"bcftools query -f '%CHROM\\t%POS\\t%INFO/END\\n' {vcf} > {extract_job.ofile}",
+    )
+    b.write_output(extract_job.ofile, output_path('sv_intervals.tsv'))
+
+    for cell_type in config['cell_types'].split(','):
+        j = b.new_python_job(name=f'Identify SV-proximal peaks: {cell_type}')
+        j.cpu(config['job_cpu'])
+        j.memory(config['job_memory'])
+        j.storage(config['job_storage'])
+
+        j.call(
+            sv_proximal_loc_extractor,
+            extract_job.ofile,
+            config['pseudobulk_dir'],
+            cell_type,
+            config['window_size'],
+        )
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/tenk10k-sv/atac/get_sv_proximal_peaks.py
+++ b/tenk10k-sv/atac/get_sv_proximal_peaks.py
@@ -30,6 +30,11 @@ def sv_proximal_loc_extractor(
     """
     Writes the subset of peaks lying within window_size of an SV to {cell_type}_loc.csv
 
+    The window covers the whole SV span plus flanks ([POS - window_size, END + window_size])
+    rather than a window around each breakpoint, so that peaks inside a large SV are retained -
+    a peak within a DEL or DUP is affected by it regardless of its distance from either
+    breakpoint. 
+
     """
     import numpy as np
     import pandas as pd

--- a/tenk10k-sv/atac/get_sv_proximal_peaks.toml
+++ b/tenk10k-sv/atac/get_sv_proximal_peaks.toml
@@ -1,6 +1,6 @@
 [get_sv_proximal_peaks]
 pseudobulk_dir = 'gs://cpg-bioheart-test/str/atac-seq'
-sv_vcf_path = 'gs://cpg-tenk10k-test/pub-analysis/final-vcf/filtered/tob_common_maf_gte_1pct.vcf.gz'  # TODO path to the SV VCF (bgzipped)
+sv_vcf_path = 'gs://cpg-tenk10k-test/pub-analysis/final-vcf/filtered/tob_common_maf_gte_1pct.vcf.gz'
 window_size = 1000000
 
 # start with one cell type, then swap in the full list of 26 below

--- a/tenk10k-sv/atac/get_sv_proximal_peaks.toml
+++ b/tenk10k-sv/atac/get_sv_proximal_peaks.toml
@@ -1,0 +1,13 @@
+[get_sv_proximal_peaks]
+pseudobulk_dir = 'gs://cpg-bioheart-test/str/atac-seq'
+sv_vcf_path = ''  # TODO path to the SV VCF (bgzipped)
+window_size = 1000000
+
+# start with one cell type, then swap in the full list of 26 below
+cell_types = 'ASDC'
+# cell_types = 'ASDC,B_intermediate,B_memory,B_naive,CD14_Mono,CD16_Mono,CD4_CTL,CD4_Naive,CD4_Proliferating,CD4_TCM,CD4_TEM,CD8_Naive,CD8_TCM,CD8_TEM,HSPC,MAIT,NK,NK_CD56bright,NK_Proliferating,Plasmablast,Treg,cDC1,cDC2,dnT,gdT,pDC'
+
+extract_job_storage = '20G'
+job_cpu = 2
+job_memory = 'standard'
+job_storage = '0G'

--- a/tenk10k-sv/atac/get_sv_proximal_peaks.toml
+++ b/tenk10k-sv/atac/get_sv_proximal_peaks.toml
@@ -1,10 +1,10 @@
 [get_sv_proximal_peaks]
 pseudobulk_dir = 'gs://cpg-bioheart-test/str/atac-seq'
-sv_vcf_path = ''  # TODO path to the SV VCF (bgzipped)
+sv_vcf_path = 'gs://cpg-tenk10k-test/pub-analysis/final-vcf/filtered/tob_common_maf_gte_1pct.vcf.gz'  # TODO path to the SV VCF (bgzipped)
 window_size = 1000000
 
 # start with one cell type, then swap in the full list of 26 below
-cell_types = 'ASDC'
+cell_types = 'CD4_TCM'
 # cell_types = 'ASDC,B_intermediate,B_memory,B_naive,CD14_Mono,CD16_Mono,CD4_CTL,CD4_Naive,CD4_Proliferating,CD4_TCM,CD4_TEM,CD8_Naive,CD8_TCM,CD8_TEM,HSPC,MAIT,NK,NK_CD56bright,NK_Proliferating,Plasmablast,Treg,cDC1,cDC2,dnT,gdT,pDC'
 
 extract_job_storage = '20G'

--- a/tenk10k-sv/sv_cluster_common.py
+++ b/tenk10k-sv/sv_cluster_common.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-function-docstring,no-member
+"""
+Cluster SVs across two GATK-SV cohort VCFs (BioHeart + TOB) and extract the
+set of variants with carriers in BOTH cohorts.
+
+Two-job pipeline:
+  1. gatk SVCluster on the two cohort VCFs -> joint_clustered.vcf.gz
+  2. bcftools split-by-cohort + isec -> common_sv.vcf.gz
+
+Inputs (all in GCS):
+  --bioheart-vcf       BioHeart cohort VCF (bgzipped + tabix-indexed)
+  --tob-vcf            TOB cohort VCF (bgzipped + tabix-indexed)
+  --bioheart-ploidy    BioHeart ploidy table (TSV, GATK-SV format)
+  --tob-ploidy         TOB ploidy table (TSV, GATK-SV format)
+  --reference-fasta    GRCh38 fasta (expects .fai and .dict siblings)
+
+analysis-runner --dataset tenk10k --access-level test \
+    --output-dir pub-analysis/sv-cluster-common \
+    --description "SVCluster across BioHeart + TOB" \
+    sv_cluster_common.py \
+        --bioheart-vcf=gs://cpg-tenk10k-test/pub-analysis/final-vcf/filtered/bioheart_common_maf_gte_1pct.vcf.gz \
+        --tob-vcf=gs://cpg-tenk10k-test/pub-analysis/final-vcf/filtered/tob_common_maf_gte_1pct.vcf.gz \
+        --ploidy=gs://cpg-tenk10k-test/sv/SVCluster/combined_ploidy.tsv \
+        --reference-fasta=gs://cpg-common-main/references/hg38/v0/Homo_sapiens_assembly38.fasta
+"""
+
+import click
+
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import get_batch, output_path
+
+
+@click.command()
+@click.option('--bioheart-vcf', required=True, help='BioHeart cohort VCF (bgzipped, .tbi sibling required)')
+@click.option('--tob-vcf', required=True, help='TOB cohort VCF (bgzipped, .tbi sibling required)')
+@click.option('--ploidy', required=True, help='Ploidy table (TSV, GATK-SV format)')
+@click.option(
+    '--reference-fasta',
+    required=True,
+    help='GRCh38 fasta; .fai and .dict siblings expected',
+)
+@click.option('--cluster-storage', default='100G', help='Disk for the SVCluster job')
+@click.option('--cluster-memory', default='64G', help='Memory for the SVCluster job')
+@click.option('--cluster-cpu', default=4, type=int, help='CPUs for the SVCluster job')
+@click.option(
+    '--cluster-algorithm',
+    default='SINGLE_LINKAGE',
+    type=click.Choice(['SINGLE_LINKAGE', 'MAX_CLIQUE', 'DEFRAGMENT_CNV']),
+    help='SVCluster --algorithm',
+)
+def main(
+    bioheart_vcf,
+    tob_vcf,
+    ploidy,
+    reference_fasta,
+    cluster_storage,
+    cluster_memory,
+    cluster_cpu,
+    cluster_algorithm,
+):
+    b = get_batch(name='SVCluster BioHeart + TOB -> common SVs')
+
+    # Read inputs. VCFs and reference come in as groups so the sibling indexes
+    # land next to the primary file inside the job.
+    bh_vcf = b.read_input_group(base=bioheart_vcf, tbi=bioheart_vcf + '.tbi')
+    tb_vcf = b.read_input_group(base=tob_vcf, tbi=tob_vcf + '.tbi')
+    r_ploidy = b.read_input(ploidy)
+    ref = b.read_input_group(
+        fasta=reference_fasta,
+        fai=reference_fasta + '.fai',
+        dict=reference_fasta.replace('.fasta', '.dict'),
+    )
+
+
+    # ---- Job 1: SVCluster --------------------------------------------------
+    cluster_job = b.new_job(name='SVCluster BioHeart + TOB')
+    cluster_job.image('australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2025-05-20-4.6.2.0-4-g1facd911e-NIGHTLY-SNAPSHOT')
+    cluster_job.storage(cluster_storage)
+    cluster_job.memory(cluster_memory)
+    cluster_job.cpu(cluster_cpu)
+    cluster_job.declare_resource_group(
+        clustered={
+            'vcf.gz': '{root}.vcf.gz',
+            'vcf.gz.tbi': '{root}.vcf.gz.tbi',
+        },
+    )
+    cluster_job.command(
+        f"""
+        set -euxo pipefail
+
+        gatk --java-options "-Xmx{cluster_memory.rstrip('G')}g" SVCluster \\
+            -V {bh_vcf.base} \\
+            -V {tb_vcf.base} \\
+            -O {cluster_job.clustered['vcf.gz']} \\
+            -R {ref.fasta} \\
+            --ploidy-table {r_ploidy} \\
+            --algorithm {cluster_algorithm}
+        """,
+    )
+
+    b.write_output(cluster_job.clustered, output_path('joint_clustered'))
+
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/tenk10k-sv/sv_vcf_for_associatr.py
+++ b/tenk10k-sv/sv_vcf_for_associatr.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""
+This script converts an existing GATK-SV VCF file into a
+mock ExpansionHunter-style VCF for direct use with associaTR.
+
+Please note ad-hoc changes:
+- RU field stores the REF and ALT alleles in the format of 'REF-ALT' (REF/ALT
+  here are the SV's symbolic alleles, e.g. 'N-<DEL>', not sequence bases)
+- RL field is set to 0 for all loci so that the REF allele is coded as 0
+  (https://github.com/gymrek-lab/TRTools/blob/master/trtools/utils/tr_harmonizer.py#L515)
+- REF field (INFO) is set to 3 (arbitrary filler value, matches SNP version)
+- SVTYPE and END are taken from the original GATK-SV INFO field (not faked),
+  since GATK-SV already provides these and they're meaningful for SVs
+- GT is extracted from whichever FORMAT slot it occupies (GATK-SV FORMAT is
+  typically GT:ECN:EV:GQ:OGQ:RD_CN:RD_GQ:SL), not assumed to be field 0 only
+  based on position -- it's located by name in the FORMAT header each time
+- Multi-allelic CNVs (FILTER contains MULTIALLELIC) do not carry meaningful
+  GT calls in GATK-SV; for these records we read FORMAT/CN (copy number) per
+  sample and emit it as "CN/0" in the mock GT slot. associaTR sums the two
+  alleles per sample, so effective per-sample dosage = CN. Missing CN is
+  written as "./.". The monomorphic-site drop uses CN directly for these
+  records.
+
+analysis-runner --dataset tenk10k-sv --access-level test --output-dir pub-analysis/final-vcf/filtered --description "sv vcf for associatr" \
+    sv_vcf_for_associatr.py --vcf-path=gs://cpg-tenk10k-sv-test/pub-analysis/final-vcf/filtered/tob_common_maf_gte_1pct.vcf.gz \
+    --job-storage=10G --job-cpu=8
+"""
+
+import gzip
+import os
+import sys
+
+import click
+from cpg_utils import to_path
+from cpg_utils.config import output_path
+from cpg_utils.hail_batch import get_batch
+
+
+# IDs that the EH-style header block below redefines. Any matching header line
+# from the source GATK-SV VCF is skipped on passthrough so the output does not
+# contain two definitions for the same INFO/FORMAT id 
+_REDEFINED_HEADER_IDS = {
+    ('INFO', 'END'),
+    ('INFO', 'REF'),
+    ('INFO', 'REPID'),
+    ('INFO', 'RL'),
+    ('INFO', 'RU'),
+    ('INFO', 'SVTYPE'),
+    ('INFO', 'VARID'),
+    ('FORMAT', 'GT'),
+    ('FORMAT', 'ADFL'),
+    ('FORMAT', 'ADIR'),
+    ('FORMAT', 'ADSP'),
+    ('FORMAT', 'LC'),
+    ('FORMAT', 'REPCI'),
+    ('FORMAT', 'REPCN'),
+    ('FORMAT', 'SO'),
+    ('FORMAT', 'QUAL'),
+}
+
+
+def _is_redefined_header(header_line):
+    """Return True if header_line declares an INFO/FORMAT id the EH block redefines."""
+    for kind in ('INFO', 'FORMAT'):
+        prefix = f'##{kind}=<ID='
+        if header_line.startswith(prefix):
+            hid = header_line[len(prefix):].split(',', 1)[0]
+            return (kind, hid) in _REDEFINED_HEADER_IDS
+    return False
+
+
+def _log_drop(reason, chrom, pos, record_id, svtype, extra=''):
+    """Emit a single-line drop record to stderr.
+
+    Format: DROP<TAB>reason<TAB>chrom<TAB>pos<TAB>id<TAB>svtype<TAB>extra
+    Grep-friendly, one line per dropped variant; also feeds the end-of-run summary.
+    """
+    print(
+        f'DROP\t{reason}\t{chrom}\t{pos}\t{record_id}\t{svtype}\t{extra}',
+        file=sys.stderr,
+    )
+
+NEW_FORMAT_FIELDS = [
+    '##FORMAT=<ID=GT,Number=1,Type=String,Description="">\n',
+    '##FORMAT=<ID=ADFL,Number=1,Type=String,Description="">\n',
+    '##FORMAT=<ID=ADIR,Number=1,Type=String,Description="">\n',
+    '##FORMAT=<ID=ADSP,Number=1,Type=String,Description="">\n',
+    '##FORMAT=<ID=LC,Number=1,Type=Float,Description="">\n',
+    '##FORMAT=<ID=REPCI,Number=1,Type=String,Description="">\n',
+    '##FORMAT=<ID=REPCN,Number=1,Type=String,Description="">\n',
+    '##FORMAT=<ID=SO,Number=1,Type=String,Description="">\n',
+    '##FORMAT=<ID=QUAL,Number=1,Type=Float,Description="">\n',
+]
+
+NEW_INFO_FIELDS = [
+    '##INFO=<ID=END,Number=1,Type=Integer,Description="">\n',
+    '##INFO=<ID=REF,Number=1,Type=Integer,Description="">\n',
+    '##INFO=<ID=REPID,Number=1,Type=String,Description="">\n',
+    '##INFO=<ID=RL,Number=1,Type=Integer,Description="">\n',
+    (
+        '##INFO=<ID=RU,Number=1,Type=String,Description="Storing the REF/ALT info instead of '
+        'Repeat Unit to retain the REF/ALT info in the association output files, which is '
+        'crucial where there are multiple variants with the same CHR:POS coordinates '
+        '(eg multi allelic loci)">\n'
+    ),
+    '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="">\n',
+    '##INFO=<ID=VARID,Number=1,Type=String,Description="">\n',
+]
+
+
+def parse_info_field(info_field):
+    """Parse a VCF INFO string into a dict, handling flag-only entries."""
+    info = {}
+    for entry in info_field.split(';'):
+        if '=' in entry:
+            key, value = entry.split('=', 1)
+            info[key] = value
+        else:
+            info[entry] = True
+    return info
+
+
+def reformat_vcf(vcf_file_path, output_file_path):
+    vcf_file = to_path(vcf_file_path)
+    output_file = to_path(output_file_path)
+
+    drop_counts = {
+        'multiallelic_no_cn': 0,
+        'monomorphic_no_callable': 0,
+        'monomorphic_uniform_dosage': 0,
+    }
+    n_seen = 0
+    n_written = 0
+
+    # Write the temp file gzip-compressed so the uploaded blob's contents match
+    # its .vcf.gz extension (inherited from the input basename in main()).
+    # A downstream bgzip+tabix step is still required before this VCF can be
+    # consumed by associatr_runner_sv.py, which expects a .vcf.bgz + .tbi pair.
+    with gzip.open(vcf_file, 'rt') as fin, gzip.open('temporary_gt_file.vcf.gz', 'wt') as fout:
+        for line in fin:
+            if line.startswith('#CHROM'):
+                # Insert the mock ExpansionHunter-style header fields right before
+                # the #CHROM line (GATK-SV VCFs don't have a ##hailversion line to
+                # key off of, unlike the hail-derived SNP VCFs).
+                fout.writelines(NEW_FORMAT_FIELDS)
+                fout.writelines(NEW_INFO_FIELDS)
+                # Declare a range of <STRn> symbolic alleles up front. MULTIALLELIC
+                # CN records emit ALT = <STR1>,<STR2>,...,<STRmax_cn> so allele
+                # indices in the mock GT (e.g. "3/0" for CN=3) resolve to a valid
+                # allele. associaTR reads <STRn> as an allele of length n
+                # (given RL=0 and a 1-char RU) so summed dosage = CN.
+                for _n in range(1, 201):
+                    fout.write(f'##ALT=<ID=STR{_n}>\n')
+                # associaTR requires sample IDs to be strictly numeric, so we
+                # remove the 'CPG' prefix
+                fout.write(line.replace('CPG', ''))
+
+            elif line.startswith('##'):
+                # Pass meta-information lines through, but drop any INFO/FORMAT
+                # header whose ID we redefine below (see _REDEFINED_HEADER_IDS)
+                # so the output has exactly one definition per ID.
+                if _is_redefined_header(line):
+                    continue
+                fout.write(line)
+
+            else:
+                # Process variant lines
+                parts = line.strip().split('\t')
+                n_seen += 1
+
+                chrom = parts[0]
+                if not chrom.startswith('chr'):
+                    parts[0] = 'chr' + chrom
+
+                record_id = parts[2] if parts[2] not in ('', '.') else 'NA'
+                filter_field = parts[6]
+                info_field = parts[7]
+                format_field = parts[8]
+                sample_data = parts[9:]
+
+                is_multiallelic = 'MULTIALLELIC' in filter_field.split(';')
+
+                info = parse_info_field(info_field)
+
+                # Pull real END/SVTYPE from the GATK-SV INFO field rather than
+                # faking them -- these are meaningful for SVs (unlike the SNP
+                # version, where END is just set equal to POS).
+                end = info.get('END', parts[1])
+                svtype = info.get('SVTYPE', 'UNKNOWN')
+
+                # RU stores ref/alt (here, the SV's symbolic alleles) so we can
+                # discriminate between loci sharing the same CHR:POS
+                new_info_fields = [
+                    f'END={end}',
+                    'REF=3',
+                    'REPID=.',
+                    'RL=0',
+                    f'RU={parts[3]}-{parts[4]}',
+                    f'SVTYPE={svtype}',
+                    'VARID=.',
+                ]
+                updated_info_field = ';'.join(new_info_fields)
+
+                # Update FORMAT field
+                updated_format_field = 'GT:ADFL:ADIR:ADSP:LC:REPCI:REPCN:SO:QUAL'
+
+                # Locate GT within the original FORMAT string by name, since
+                # GATK-SV FORMAT has several subfields
+                # (GT:ECN:EV:GQ:OGQ:RD_CN:RD_GQ:SL) and GT isn't guaranteed to
+                # be the only field even though it is field 0 by VCF spec --
+                # this makes the lookup explicit rather than assumed.
+                format_keys = format_field.split(':')
+
+                # Build the mock per-sample GT strings and the paired
+                # per-sample dosage values used for the monomorphic drop.
+                # MULTIALLELIC CNVs go through the CN path (emit "CN/0");
+                # everything else goes through the standard GT path.
+                mock_gts = []
+                summed_gt_values = []
+
+                if is_multiallelic:
+                    if 'CN' not in format_keys:
+                        # No CN available for a multi-allelic CNV -> no dosage
+                        # to recover; drop the site.
+                        drop_counts['multiallelic_no_cn'] += 1
+                        _log_drop(
+                            'multiallelic_no_cn',
+                            parts[0], parts[1], record_id, svtype,
+                            extra=f'FORMAT={format_field}',
+                        )
+                        continue
+                    cn_index = format_keys.index('CN')
+                    for sample in sample_data:
+                        sample_parts = sample.split(':')
+                        cn_val = sample_parts[cn_index] if cn_index < len(sample_parts) else '.'
+                        if cn_val in ('', '.'):
+                            mock_gts.append('./.')
+                            continue
+                        try:
+                            cn_int = int(cn_val)
+                        except ValueError:
+                            mock_gts.append('./.')
+                            continue
+                        mock_gts.append(f'{cn_int}/0')
+                        summed_gt_values.append(cn_int)
+                else:
+                    gt_index = format_keys.index('GT') if 'GT' in format_keys else 0
+                    for sample in sample_data:
+                        sample_parts = sample.split(':')
+                        gt = sample_parts[gt_index].replace('|', '/')
+                        mock_gts.append(gt if gt not in ('', '.') else './.')
+                        if gt in ('', '.', './.'):
+                            continue
+                        alleles = gt.split('/')
+                        if any(a == '.' for a in alleles):
+                            continue
+                        try:
+                            summed_gt_values.append(sum(int(a) for a in alleles))
+                        except ValueError:
+                            continue
+
+                if len(summed_gt_values) == 0:
+                    drop_counts['monomorphic_no_callable'] += 1
+                    _log_drop(
+                        'monomorphic_no_callable',
+                        parts[0], parts[1], record_id, svtype,
+                        extra=f'n_samples={len(sample_data)}',
+                    )
+                    continue
+                if all(sum_gt == summed_gt_values[0] for sum_gt in summed_gt_values):
+                    drop_counts['monomorphic_uniform_dosage'] += 1
+                    _log_drop(
+                        'monomorphic_uniform_dosage',
+                        parts[0], parts[1], record_id, svtype,
+                        extra=f'dosage={summed_gt_values[0]};n_callable={len(summed_gt_values)}',
+                    )
+                    continue
+
+                updated_sample_data = [':'.join([gt] + ['.'] * 8) for gt in mock_gts]
+                n_written += 1
+
+                # Update ALT column. MULTIALLELIC CN records emit GTs like "3/0",
+                # "4/0", ... so the ALT column must declare enough symbolic
+                # alleles for those indices to resolve; otherwise associaTR
+                # crashes with IndexError inside GetLengthGenotypes (allele_lens
+                # lookup out of bounds). associaTR reads <STRn> as an allele of
+                # length n, so ALT = <STR1>,<STR2>,...,<STRmax_cn> gives:
+                #   GT 0/0 -> summed dosage 0
+                #   GT k/0 -> summed dosage k   (equal to CN)
+                if is_multiallelic:
+                    max_cn = max(summed_gt_values)  # >=1 here (0-only would have been dropped as monomorphic)
+                    parts[4] = ','.join(f'<STR{i}>' for i in range(1, max_cn + 1))
+                else:
+                    parts[4] = '<STR1>'
+
+                # Write the updated line to the output file
+                updated_line = '\t'.join(
+                    parts[:7] + [updated_info_field, updated_format_field] + updated_sample_data,
+                )
+                fout.write(updated_line + '\n')
+
+    total_dropped = sum(drop_counts.values())
+    print(
+        f'SUMMARY\tinput={vcf_file_path}\tseen={n_seen}\twritten={n_written}\t'
+        f'dropped={total_dropped}\t'
+        + '\t'.join(f'{k}={v}' for k, v in drop_counts.items()),
+        file=sys.stderr,
+    )
+
+    output_file.upload_from('temporary_gt_file.vcf.gz')
+
+
+@click.option('--vcf-path', required=True, help='Input VCF file')
+@click.option('--job-storage', default='20G')
+@click.option('--job-cpu', default=1)
+@click.command()
+def main(vcf_path, job_storage, job_cpu):
+    b = get_batch(name='SV VCF maker for associaTR')
+
+    sv_vcf = vcf_path
+    output_file = output_path(
+        f'sv_vcf_for_associatr/{os.path.basename(vcf_path)}',
+    )
+
+    reformatting_job = b.new_python_job(name=f'Reformatting VCF')
+    reformatting_job.storage(job_storage)
+    reformatting_job.cpu(job_cpu)
+    reformatting_job.call(reformat_vcf, sv_vcf, output_file)
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Add SV-proximal ATAC peak filtering

Identifies the ATAC-seq peaks that fall within a window (default 1Mb) of any SV in a
given VCF, per cell type. The output slots into the current ATAC
associatr path.

### Why

`str/atac/get_cis_numpy.py` filters peaks down to a precomputed "sites within 1Mb of an
eSV" list read from `loc_filtered_dir` (`{cell_type}_loc.csv`). There was no equivalent
for SVs, so there was no way to restrict the ATAC association testing to peaks near a
structural variant.

### What it does

Two stages, both in one Hail Batch:

1. **`Extract SV intervals`** (bcftools, runs once) — pulls `CHROM/POS/INFO/END` out of the
   VCF into a compact TSV, also written to the output dir as `sv_intervals.tsv` for
   provenance. Doing this once keeps the multi-GB VCF off the analysis-runner driver and
   out of the per-cell-type jobs.
2. **`Identify SV-proximal peaks`** (one Python job per cell type) — reads just the `loc`
   column of `PseudobulkMatStandardised.csv`, expands each SV to
   `[POS - window_size, END + window_size]`, merges those into disjoint intervals, and
   tests each peak with a single binary search.

### Output

`{cell_type}_loc.csv`, a single `loc` column — a drop-in for the `loc_filtered_dir` input
of `str/atac/get_cis_numpy.py`, so switching that pipeline from eSTR-proximal to
SV-proximal peaks is a config change only.
